### PR TITLE
MiMa build version is now injected using ``sbt-buildinfo`` plugin

### DIFF
--- a/core-ui/src/main/scala/com/typesafe/tools/mima/core/ui/MimaFrame.scala
+++ b/core-ui/src/main/scala/com/typesafe/tools/mima/core/ui/MimaFrame.scala
@@ -6,7 +6,7 @@ import com.typesafe.tools.mima.core.ui._
 import com.typesafe.tools.mima.core.ui.wizard._
 import com.typesafe.tools.mima.core.Config
 import com.typesafe.tools.mima.core.ui.event.ExitMiMa
-import com.typesafe.tools.mima.core.util.Version
+import com.typesafe.tools.mima.core.buildinfo.BuildInfo
 
 import scala.tools.nsc.{ util, io }
 import util._
@@ -19,7 +19,7 @@ abstract class MimaFrame extends MainFrame with Centered {
 
   object TypesafeLogo extends widget.LinkImagePanel(TypesafeSite, images.Icons.typesafe)
 
-  title = "Migration Manager - " + Version.version
+  title = "Migration Manager - " + BuildInfo.version
   preferredSize = (1024, 768)
   minimumSize = preferredSize
   location = center

--- a/core/src/main/scala/com/typesafe/tools/mima/core/util/Version.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/util/Version.scala
@@ -1,6 +1,0 @@
-package com.typesafe.tools.mima.core.util
-
-object Version {
-  // FIXME: I need a plugin that can filter resources...
-  val version = "v.0.1.1" 
-}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,6 +10,7 @@ import sbtassembly.Plugin.AssemblyKeys
 import sbtassembly.Plugin.AssemblyKeys._
 import sbtassembly.Plugin.assemblySettings
 import sbtassembly.Plugin.MergeStrategy
+import sbtbuildinfo.Plugin._
 
 object BuildSettings {
   
@@ -96,7 +97,13 @@ object MimaBuild extends Build {
 
   lazy val core = (
     Project("core", file("core"), 
-            settings = commonSettings)
+            settings = commonSettings ++: buildInfoSettings ++: Seq(
+                sourceGenerators in Compile <+= buildInfo,
+                buildInfoKeys := Seq[Scoped](version),
+                buildInfoPackage := "com.typesafe.tools.mima.core.buildinfo",
+                buildInfoObject  := "BuildInfo"
+                )
+           )
     settings(libraryDependencies ++= Seq(compiler, specs2),
              name := buildName + "-core")
     settings(sonatypePublishSettings:_*)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.1")
 
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.1.2")
+
 resolvers += Resolver.url("sbt-plugin-releases",
   new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)


### PR DESCRIPTION
Added `sbt-buildinfo` plugin to MiMa core project definition, so that
the `buildVersion` defined inside `Build.scala` is now injected during
sbt source-generation phase.

Fixed #9

As part of this pull request, I should also update the README and provide some information on how to correctly set up `sbteclipse`, because the `src-managed` folder has to be listed in the project's build-path. According to [sbteclipse doc](https://github.com/typesafehub/sbteclipse/wiki/Using-sbteclipse#wiki-createsrc) I need something like the following:

``` scala
EclipseKeys.createSrc := EclipseCreateSrc.Default + EclipseCreateSrc.Managed
```

But given my unfamiliarity with sbt, I'm not sure where this should go. Would you guys have any idea? 
