### PR TITLE
Preparing 0.1.5 release

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -20,7 +20,7 @@ object BuildSettings {
   val buildOrganization = "com.typesafe"
 
   val buildScalaVer = "2.9.2"
-  val buildVersion = "0.1.5-SNAPSHOT"
+  val buildVersion = "0.1.5"
 
   val commonSettings = Defaults.defaultSettings ++ Seq (
       organization := buildOrganization,


### PR DESCRIPTION
- Bumped version

_Merge this only after the release has been actually pushed_

Use the [tag 0.1.5](https://github.com/typesafehub/migration-manager/tree/0.1.5) for releasing.
