### PR TITLE
Package level whitelisting

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/Filters.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Filters.scala
@@ -26,4 +26,13 @@ object ProblemFilters {
     val problemClass: Class[_ <: ProblemRef] = Class.forName("com.typesafe.tools.mima.core." + problemName).asInstanceOf[Class[_ <: ProblemRef]]
     exclude(name)(ClassManifest.fromClass(problemClass))
   }
+
+  private case class ExcludeByPackage(excludedPackageName: String) extends ProblemFilter {
+    def apply(problem: Problem): Boolean = {
+      // careful to avoid excluding "com.foobar" with an exclusion "com.foo"
+      !problem.matchName.getOrElse("").startsWith(excludedPackageName + ".")
+    }
+  }
+
+  def excludePackage(packageName: String): ProblemFilter = new ExcludeByPackage(packageName)
 }

--- a/reporter/src/main/scala/com/typesafe/tools/mima/cli/Main.scala
+++ b/reporter/src/main/scala/com/typesafe/tools/mima/cli/Main.scala
@@ -84,7 +84,9 @@ class Main(args: List[String]) extends {
   private def loadFilters(configFile: File): Seq[ProblemFilter] = {
     import com.typesafe.config._
     try {
-      val config: Config = ConfigFactory.parseFile(configFile).resolve
+      val fallback = ConfigFactory.parseString("filter { problems = []\npackages=[] }")
+      val config: Config =
+        ConfigFactory.parseFile(configFile).withFallback(fallback).resolve()
       ProblemFiltersConfig.parseProblemFilters(config)
     } catch {
       case e: Exception =>

--- a/reporter/src/main/scala/com/typesafe/tools/mima/cli/ProblemFiltersConfig.scala
+++ b/reporter/src/main/scala/com/typesafe/tools/mima/cli/ProblemFiltersConfig.scala
@@ -7,6 +7,7 @@ import scala.collection.JavaConverters._
 
 object ProblemFiltersConfig {
   private val filterProblemsPath = "filter.problems"
+  private val filterPackagesPath = "filter.packages"
   private val problemNameKey = "problemName"
   private val matchNameKey = "matchName"
 
@@ -19,11 +20,16 @@ object ProblemFiltersConfig {
    */
   def parseProblemFilters(config: Config): Seq[ProblemFilter] = {
     val filters = config.getConfigList(filterProblemsPath).asScala.toSeq
-    for (problemConfig <- filters) yield {
+    val individualFilter = for (problemConfig <- filters) yield {
       val problemClassName = problemConfig.getString(problemNameKey)
       val matchName = problemConfig.getString(matchNameKey)
       ProblemFilters.exclude(problemClassName, matchName)
     }
+    val packages = config.getStringList(filterPackagesPath).asScala.toSeq
+    val packageFilter = for (pack <- packages) yield {
+      ProblemFilters.excludePackage(pack)
+    }
+    individualFilter ++ packageFilter
   }
 
   /**


### PR DESCRIPTION
Adds support for package level filter such as:

```
filter {
    packages = [
        "scala.reflect.internal",
    ]
}
```

Changes the config loading to use a default config, to
avoid errors if we load a whitelist that only has one of
`problems` or `packages`.

Tested manually with the build from Scala 2.10.2.

Procedure:
1. Publish modified version of MiMa to my local maven repo:
   
   sbt> set every publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))
   sbt> publish
2. Point to the new version in mima.classpath in scala/scala's build.xml
3. Induce a BC failure (actually its enough to build without -optimize, `ant build test.bc`)
4. Filter this out with `packages = ["scala.xml"]`.
5. Confirm that the problem _isn't_ filtered if:
   - the `packages` section is omitted entirely
   - the `packages` section exists, but is empty
   - the `packages` section contains "scala.xm" or "scala.xmllll"

Review by @gkossakowski
