### PR TITLE
Use Class#getDeclaredConstructor()#newInstance()

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -274,7 +274,7 @@ object MimaBuild {
     val loader = new java.net.URLClassLoader(urls, si.loader)
 
     val testClass = loader.loadClass("com.typesafe.tools.mima.lib.CollectProblemsTest")
-    val testRunner = testClass.newInstance().asInstanceOf[ {
+    val testRunner = testClass.getDeclaredConstructor().newInstance().asInstanceOf[ {
       def runTest(testClasspath: Array[String], testName: String, oldJarPath: String,
           newJarPath: String, oraclePath: String, filterPath: String): Unit
     }]


### PR DESCRIPTION
This makes the reflection usage compatible with Java 11, where
Class#newInstance is deprecated (and we have fatal warnings enabled in
the meta-build).