### PR TITLE
Add a ko test for value classes in a generic context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ script: sbt "++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues" "++$TRAVIS_SCALA_VE
 
 jobs:
   include:
+  - { name: 2.12 testFunctional scala/scala#8127, script: sbt -Dmima.buildScalaVersion=2.12.8 -Dmima.testScalaVersion=2.12.9-bin-369c743-SNAPSHOT testFunctional }
   - { name: 2.12 testFunctional 2.11, script: sbt -Dmima.buildScalaVersion=2.12.8 -Dmima.testScalaVersion=2.11.12 testFunctional }
   - { name: 2.12 testFunctional 2.12, script: sbt -Dmima.buildScalaVersion=2.12.8 -Dmima.testScalaVersion=2.12.8  testFunctional }
   - { name: 2.12 testFunctional 2.13, script: sbt -Dmima.buildScalaVersion=2.12.8 -Dmima.testScalaVersion=2.13.0  testFunctional }

--- a/functional-tests/src/test/value-class-generic-replacement-nok/problems.txt
+++ b/functional-tests/src/test/value-class-generic-replacement-nok/problems.txt
@@ -1,0 +1,1 @@
+method boxedStringy()scala.Option in class Bar has a different signature in new version, where it is ()Lscala/Option<LFoo;>; rather than ()Lscala/Option<Ljava/lang/String;>;

--- a/functional-tests/src/test/value-class-generic-replacement-nok/v1/A.scala
+++ b/functional-tests/src/test/value-class-generic-replacement-nok/v1/A.scala
@@ -1,0 +1,5 @@
+final class Foo(val value: String) extends AnyVal
+
+final class Bar {
+  def boxedStringy = Option("hi")
+}

--- a/functional-tests/src/test/value-class-generic-replacement-nok/v2/A.scala
+++ b/functional-tests/src/test/value-class-generic-replacement-nok/v2/A.scala
@@ -1,0 +1,5 @@
+final class Foo(val value: String) extends AnyVal
+
+final class Bar {
+  def boxedStringy = Option(new Foo("hi"))
+}


### PR DESCRIPTION
This test case is derived by the in-flight scala/scala#8127 PR.

Turns out that MiMa is already correctly handling this, as of @raboof's wonderful fix in #299.

("Someone" (i.e. me) should really release that to MiMa users...)