### PR TITLE
Reconfigure functional tests to use the test key

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,10 +29,7 @@ val core = project.disablePlugins(BintrayPlugin).settings(
   libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
   libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0-SNAP13" % Test,
   MimaSettings.mimaSettings,
-  publishTo := Some(
-    if (isSnapshot.value) "snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
-    else                  "releases"  at "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-  ),
+  publishTo := Some(if (isSnapshot.value) Opts.resolver.sonatypeSnapshots else Opts.resolver.sonatypeStaging),
   pomIncludeRepository := (_ => false),
 )
 

--- a/project/TestsPlugin.scala
+++ b/project/TestsPlugin.scala
@@ -25,7 +25,7 @@ object TestsPlugin extends AutoPlugin {
   )
 
   override def projectSettings = Seq(
-    testFunctional := dependOnAll(testFunctional in _).value,
+    testFunctional := dependOnAll(test in _).value,
     test in IntegrationTest := dependOnAll(test in IntegrationTest in _).value,
   )
 
@@ -111,7 +111,7 @@ object TestsPlugin extends AutoPlugin {
     crossScalaVersions := Seq("2.12.8", "2.13.0"),
     inConfig(V1)(perConfig), // add compile/package for the V1 sources
     inConfig(V2)(perConfig), // add compile/package for the V2 sources
-    testFunctional := runTest.value, // add the testFunctional task
+    test := runTest.value,
   )
 
   def runCollectProblemsTest(


### PR DESCRIPTION
This is for dbuild compatibility: https://github.com/scala/community-builds/pull/926