### PR TITLE
Verify all overloads for result types & signatures

### DIFF
--- a/functional-tests/src/it/scala-library-2-11/test.conf
+++ b/functional-tests/src/it/scala-library-2-11/test.conf
@@ -3,39 +3,13 @@ artifactId = "scala-library"
 v1 = "2.11.0"
 v2 = "2.11.12"
 
-filter {
-  problems=[
-    {
-      matchName="scala.None.toRight"
-      problemName=IncompatibleSignatureProblem
-    },
-    {
-      matchName="scala.None.toLeft"
-      problemName=IncompatibleSignatureProblem
-    },
-    {
-      matchName="scala.Option.toRight"
-      problemName=IncompatibleSignatureProblem
-    },
-    {
-      matchName="scala.Option.toLeft"
-      problemName=IncompatibleSignatureProblem
-    },
-    {
-      matchName="scala.util.Either#LeftProjection.map"
-      problemName=IncompatibleSignatureProblem
-    },
-    {
-      matchName="scala.util.Either#RightProjection.map"
-      problemName=IncompatibleSignatureProblem
-    },
-    {
-      matchName="scala.util.Either.swap"
-      problemName=IncompatibleSignatureProblem
-    },
-    {
-      matchName="scala.collection.*.foreach"
-      problemName=IncompatibleSignatureProblem
-    }
-  ]
-}
+filter.problems=[
+  { problemName=IncompatibleSignatureProblem, matchName="scala.None.toLeft" }
+  { problemName=IncompatibleSignatureProblem, matchName="scala.None.toRight" }
+  { problemName=IncompatibleSignatureProblem, matchName="scala.Option.toLeft" }
+  { problemName=IncompatibleSignatureProblem, matchName="scala.Option.toRight" }
+  { problemName=IncompatibleSignatureProblem, matchName="scala.collection.*.foreach" }
+  { problemName=IncompatibleSignatureProblem, matchName="scala.util.Either#LeftProjection.map" }
+  { problemName=IncompatibleSignatureProblem, matchName="scala.util.Either#RightProjection.map" }
+  { problemName=IncompatibleSignatureProblem, matchName="scala.util.Either.swap" }
+]

--- a/functional-tests/src/it/scala-reflect-2-10/test.conf
+++ b/functional-tests/src/it/scala-reflect-2-10/test.conf
@@ -3,31 +3,11 @@ artifactId = "scala-reflect"
 v1 = "2.10.0"
 v2 = "2.10.7"
 
-filter {
-  problems=[
-    {
-      matchName="scala.reflect.internal.*"
-      problemName=Problem
-    },
-    {
-      matchName="scala.reflect.macros.Attachments$NonemptyAttachments"
-      problemName=MissingClassProblem
-    },
-    {
-      matchName="scala.reflect.runtime.JavaUniverse.isInvalidClassName"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.runtime.SymbolLoaders.isInvalidClassName"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.io.ZipArchive#Entry.underlyingSource"
-      problemName=IncompatibleResultTypeProblem
-    },
-    {
-      matchName="scala.reflect.io.ZipArchive.underlyingSource"
-      problemName=IncompatibleResultTypeProblem
-    }
-  ]
-}
+filter.problems = [
+  { problemName=Problem, matchName="scala.reflect.internal.*" }
+  { problemName=MissingClassProblem,  matchName="scala.reflect.macros.Attachments$NonemptyAttachments" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.runtime.JavaUniverse.isInvalidClassName" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.runtime.SymbolLoaders.isInvalidClassName" }
+  { problemName=IncompatibleResultTypeProblem, matchName="scala.reflect.io.ZipArchive#Entry.underlyingSource" }
+  { problemName=IncompatibleResultTypeProblem, matchName="scala.reflect.io.ZipArchive.underlyingSource" }
+]

--- a/functional-tests/src/it/scala-reflect-2-10/test.conf
+++ b/functional-tests/src/it/scala-reflect-2-10/test.conf
@@ -8,6 +8,6 @@ filter.problems = [
   { problemName=MissingClassProblem,  matchName="scala.reflect.macros.Attachments$NonemptyAttachments" }
   { problemName=MissingMethodProblem, matchName="scala.reflect.runtime.JavaUniverse.isInvalidClassName" }
   { problemName=MissingMethodProblem, matchName="scala.reflect.runtime.SymbolLoaders.isInvalidClassName" }
-  { problemName=IncompatibleResultTypeProblem, matchName="scala.reflect.io.ZipArchive#Entry.underlyingSource" }
-  { problemName=IncompatibleResultTypeProblem, matchName="scala.reflect.io.ZipArchive.underlyingSource" }
+  { problemName=IncompatibleSignatureProblem, matchName="scala.reflect.io.ZipArchive#Entry.underlyingSource" }
+  { problemName=IncompatibleSignatureProblem, matchName="scala.reflect.io.ZipArchive.underlyingSource" }
 ]

--- a/functional-tests/src/it/scala-reflect-2-11/test.conf
+++ b/functional-tests/src/it/scala-reflect-2-11/test.conf
@@ -3,107 +3,30 @@ artifactId = "scala-reflect"
 v1 = "2.11.0"
 v2 = "2.11.12"
 
-filter {
-  problems=[
-    {
-      matchName="scala.reflect.internal.*"
-      problemName=Problem
-    },
-    {
-      matchName="scala.reflect.api.StandardLiftables#StandardLiftableInstances.liftTree"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi#SyntacticTypeAppliedExtractor.unapply"
-      problemName=IncompatibleResultTypeProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi#SyntacticTypeAppliedExtractor.unapply"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticSelectType"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticAppliedType"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticSelectTerm"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticPartialFunction"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Mirror.symbolOf"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Mirror.typeOf"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Mirror.weakTypeOf"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals$ReificationSupportApi$SyntacticIdentExtractor"
-      problemName=MissingClassProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticIdent"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticSingletonType"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticTermIdent"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticTypeIdent"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticCompoundType"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticAnnotatedType"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticTypeProjection"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticExistentialType"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.runtime.SynchronizedOps.newNestedScope"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.runtime.ThreadLocalStorage#MyThreadLocalStorage.values"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.io.ZipArchive.scala$reflect$io$ZipArchive$$walkIterator"
-      problemName=MissingMethodProblem
-    },
-    {
-      matchName="scala.reflect.io.ZipArchive#Entry.underlyingSource"
-      problemName=IncompatibleResultTypeProblem
-    },
-    {
-      matchName="scala.reflect.io.ZipArchive.underlyingSource"
-      problemName=IncompatibleResultTypeProblem
-    }
-  ]
-}
+filter.problems=[
+  { problemName=Problem, matchName="scala.reflect.internal.*" }
+  { problemName=IncompatibleResultTypeProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi#SyntacticTypeAppliedExtractor.unapply" }
+  { problemName=IncompatibleResultTypeProblem, matchName="scala.reflect.io.ZipArchive#Entry.underlyingSource" }
+  { problemName=IncompatibleResultTypeProblem, matchName="scala.reflect.io.ZipArchive.underlyingSource" }
+  { problemName=MissingClassProblem,  matchName="scala.reflect.api.Internals$ReificationSupportApi$SyntacticIdentExtractor" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.StandardLiftables#StandardLiftableInstances.liftTree" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi#SyntacticTypeAppliedExtractor.unapply" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticAnnotatedType" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticAppliedType" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticCompoundType" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticExistentialType" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticIdent" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticPartialFunction" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticSelectTerm" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticSelectType" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticSingletonType" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticTermIdent" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticTypeIdent" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi.SyntacticTypeProjection" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Mirror.symbolOf" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Mirror.typeOf" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.api.Mirror.weakTypeOf" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.io.ZipArchive.scala$reflect$io$ZipArchive$$walkIterator" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.runtime.SynchronizedOps.newNestedScope" }
+  { problemName=MissingMethodProblem, matchName="scala.reflect.runtime.ThreadLocalStorage#MyThreadLocalStorage.values" }
+]

--- a/functional-tests/src/it/scala-reflect-2-11/test.conf
+++ b/functional-tests/src/it/scala-reflect-2-11/test.conf
@@ -6,8 +6,8 @@ v2 = "2.11.12"
 filter.problems=[
   { problemName=Problem, matchName="scala.reflect.internal.*" }
   { problemName=IncompatibleResultTypeProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi#SyntacticTypeAppliedExtractor.unapply" }
-  { problemName=IncompatibleResultTypeProblem, matchName="scala.reflect.io.ZipArchive#Entry.underlyingSource" }
-  { problemName=IncompatibleResultTypeProblem, matchName="scala.reflect.io.ZipArchive.underlyingSource" }
+  { problemName=IncompatibleSignatureProblem, matchName="scala.reflect.io.ZipArchive#Entry.underlyingSource" }
+  { problemName=IncompatibleSignatureProblem, matchName="scala.reflect.io.ZipArchive.underlyingSource" }
   { problemName=MissingClassProblem,  matchName="scala.reflect.api.Internals$ReificationSupportApi$SyntacticIdentExtractor" }
   { problemName=MissingMethodProblem, matchName="scala.reflect.api.StandardLiftables#StandardLiftableInstances.liftTree" }
   { problemName=MissingMethodProblem, matchName="scala.reflect.api.Internals#ReificationSupportApi#SyntacticTypeAppliedExtractor.unapply" }

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
@@ -1,16 +1,14 @@
 package com.typesafe.tools.mima.lib
 
-import com.typesafe.tools.mima.core.Config
-import com.typesafe.tools.mima.core.{asClassPathString, baseClassPath}
-import java.io.{BufferedInputStream, File, FileInputStream}
+import java.io.File
 
 import com.typesafe.config.ConfigFactory
-import com.typesafe.tools.mima.core.Config
+import com.typesafe.tools.mima.core.{ Config, Problem, asClassPathString, baseClassPath }
 
 import scala.io.Source
 import scala.tools.nsc.util._
 
-case class TestFailed(msg: String) extends Exception(msg)
+final case class TestFailed(msg: String) extends Exception(msg)
 
 class CollectProblemsTest {
 
@@ -26,42 +24,40 @@ class CollectProblemsTest {
     // SUT
     val allProblems = mima.collectProblems(oldJarPath, newJarPath)
 
-    val problems = (if (filterPath ne null) {
+    val problems = if (filterPath ne null) {
       val fallback = ConfigFactory.parseString("filter { problems = [] }")
       val config = ConfigFactory.parseFile(new File(filterPath)).withFallback(fallback).resolve()
       val filters = ProblemFiltersConfig.parseProblemFilters(config)
       allProblems.filter(p => filters.forall(_.apply(p)))
-    } else allProblems).map(_.description("new"))
+    } else allProblems
+    val problemDescriptions = problems.iterator.map(_.description("new")).toSet
 
     // load oracle
-    val inputStream = new BufferedInputStream(new FileInputStream(oraclePath))
-    val expectedProblems = try {
-      Source.fromInputStream(inputStream).getLines
-        .filter(!_.startsWith("#"))
-        .toList
-    } finally inputStream.close()
+    val source = Source.fromFile(oraclePath)
+    val expectedProblems = try source.getLines.filter(!_.startsWith("#")).toList finally source.close()
 
     // diff between the oracle and the collected problems
-    val unexpectedProblems = problems.filterNot(expectedProblems.contains)
-    val unreportedProblems = expectedProblems.filterNot(problems.contains)
+    val unexpectedProblems = problems.filterNot(p => expectedProblems.contains(p.description("new")))
+    val unreportedProblems = expectedProblems.filterNot(problemDescriptions.contains)
 
-    val mess = buildErrorMessage(unexpectedProblems, unreportedProblems)
+    val msg = buildErrorMessage(unexpectedProblems, unreportedProblems)
 
-    if (!mess.isEmpty)
-      throw new TestFailed(testName + "' failed.\n" + mess)
+    if (!msg.isEmpty)
+      throw TestFailed(s"'$testName' failed.\n$msg")
   }
 
-  private def buildErrorMessage(unexpectedProblems: List[String], unreportedProblems: List[String]): String = {
-    val mess = new StringBuilder
+  private def buildErrorMessage(unexpectedProblems: List[Problem], unreportedProblems: List[String]): String = {
+    val msg = new StringBuilder
 
-    if (!unexpectedProblems.isEmpty)
-      mess ++= "\tThe following problems were not expected\n" + unexpectedProblems.mkString("\t- ", "\n\t- ", "")
+    if (unexpectedProblems.nonEmpty)
+      unexpectedProblems.iterator
+          .map(p => s"${p.getClass.getSimpleName}: ${p.description("new")}")
+          .addString(msg, "\tThe following problems were not expected\n\t- ", "\n\t- ", "\n\n")
 
-    if (!mess.isEmpty) mess ++= "\n\n"
+    if (unreportedProblems.nonEmpty)
+      //noinspection ScalaUnusedExpression // intellij-scala is wrong, addString _does_ side-effect
+      unreportedProblems.addString(msg, "\tThe following expected problems were not reported\n\t- ", "\n\t- ", "\n")
 
-    if (!unreportedProblems.isEmpty)
-      mess ++= "\tThe following expected problems were not reported\n" + unreportedProblems.mkString("\t- ", "\n\t- ", "\n")
-
-    mess.toString
+    msg.result()
   }
 }

--- a/project/TestsPlugin.scala
+++ b/project/TestsPlugin.scala
@@ -25,7 +25,7 @@ object TestsPlugin extends AutoPlugin {
   )
 
   override def projectSettings = Seq(
-            testFunctional := dependOnAll(_ /                   test).value,
+            testFunctional := dependOnAll(_ /            Test / test).value,
     IntegrationTest / test := dependOnAll(_ / IntegrationTest / test).value,
   )
 
@@ -106,7 +106,7 @@ object TestsPlugin extends AutoPlugin {
     crossScalaVersions := Seq("2.12.8", "2.13.0"),
     inConfig(V1)(testPerConfigSettings),
     inConfig(V2)(testPerConfigSettings),
-    test := runFunctionalTest.value,
+    Test / test := runFunctionalTest.value,
   )
 
   private def runCollectProblemsTest(

--- a/project/TestsPlugin.scala
+++ b/project/TestsPlugin.scala
@@ -8,8 +8,6 @@ import sbt.internal.inc.ScalaInstance
 import sbt.librarymanagement.{ DependencyResolution, UnresolvedWarningConfiguration, UpdateConfiguration }
 
 object TestsPlugin extends AutoPlugin {
-  override def extraProjects = tests ++ integrationTests
-
   object autoImport {
     // This is the key for the scala version used to compile the tests, so that we can cross test the MiMa version
     // actually being used in the sbt plugin against multiple scala compiler versions.
@@ -20,109 +18,106 @@ object TestsPlugin extends AutoPlugin {
   }
   import autoImport._
 
+  override def extraProjects = tests ++ integrationTests
+
   override def buildSettings = Seq(
     testScalaVersion := sys.props.getOrElse("mima.testScalaVersion", scalaVersion.value),
   )
 
   override def projectSettings = Seq(
-    testFunctional := dependOnAll(test in _).value,
-    test in IntegrationTest := dependOnAll(test in IntegrationTest in _).value,
+            testFunctional := dependOnAll(_ /                   test).value,
+    IntegrationTest / test := dependOnAll(_ / IntegrationTest / test).value,
   )
 
-  val functionalTests = LocalProject("functional-tests")
+  private val functionalTests = LocalProject("functional-tests")
 
   // define configurations for the V1 and V2 sources
-  val V1 = config("V1") extend Compile
-  val V2 = config("V2") extend Compile
+  private val V1 = config("V1").extend(Compile)
+  private val V2 = config("V2").extend(Compile)
 
   // select all testN directories.
-  val bases = (file("functional-tests") / "src" / "test") *
-    (DirectoryFilter && new SimpleFileFilter(_.list.contains("problems.txt")))
-
-  val integrationTestBases = (file("functional-tests") / "src" / "it") *
-    (DirectoryFilter && new SimpleFileFilter(_.list.contains("test.conf")))
+  private val bases                = file("functional-tests") / "src" / "test" * dirContaining("problems.txt")
+  private val integrationTestBases = file("functional-tests") / "src" / "it" * dirContaining("test.conf")
 
   // make the Project for each discovered directory
-  lazy val tests            = bases.get map testProject
-  lazy val integrationTests = integrationTestBases.get map integrationTestProject
+  private lazy val tests            = bases.get.map(testProject)
+  private lazy val integrationTests = integrationTestBases.get.map(integrationTestProject)
 
-  def integrationTestProject(base: File) =
-    Project("it-" + base.name, base).disablePlugins(BintrayPlugin).settings(integrationTestProjectSettings)
+  private def integrationTestProject(base: File) =
+    Project(s"it-${base.name}", base).disablePlugins(BintrayPlugin).settings(integrationTestProjectSettings)
 
-  val runIntegrationTest = Def.task {
-    val proj = thisProjectRef.value // gives us the ProjectRef this task is defined in
+  private val runIntegrationTest = Def.task {
     val confFile = baseDirectory.value / "test.conf"
     val conf = ConfigFactory.parseFile(confFile).resolve()
     val moduleBase = conf.getString("groupId") % conf.getString("artifactId")
-    val depRes: DependencyResolution = dependencyResolution.value
-    val jar1 = getArtifact(depRes, moduleBase % conf.getString("v1"), streams.value)
-    val jar2 = getArtifact(depRes, moduleBase % conf.getString("v2"), streams.value)
-    streams.value.log.info(s"Comparing $jar1 -> $jar2")
+    val depRes = dependencyResolution.value
+    val oldJar = getArtifact(depRes, moduleBase % conf.getString("v1"), streams.value.log)
+    val newJar = getArtifact(depRes, moduleBase % conf.getString("v2"), streams.value.log)
+    streams.value.log.info(s"Comparing $oldJar -> $newJar")
     runCollectProblemsTest(
-      (fullClasspath in (functionalTests, Compile)).value, // the test classpath from the functionalTest project for the test
-      (scalaInstance in functionalTests).value, // get a reference to the already loaded Scala classes so we get the advantage of a warm jvm
+      (functionalTests / Compile / fullClasspath).value, // the test classpath from the functionalTest project for the test
+      (functionalTests / scalaInstance).value, // get a reference to the already loaded Scala classes so we get the advantage of a warm jvm
       streams.value,
-      proj.project,
-      jar1,
-      jar2,
+      thisProjectRef.value.project,
+      oldJar,
+      newJar,
       baseDirectory.value,
       scalaVersion.value,
       confFile.getAbsolutePath)
   }
 
-  val integrationTestProjectSettings = Def.settings(
+  private val integrationTestProjectSettings = Def.settings(
     scalaVersion := testScalaVersion.value,
     crossScalaVersions := Seq("2.12.8", "2.13.0"),
-    test in IntegrationTest := runIntegrationTest.value,
+    IntegrationTest / test := runIntegrationTest.value,
   )
 
   // defines a Project for the given base directory (for example, functional-tests/test1)
   // Its name is the directory name (test1) and it has compile+package tasks for sources in v1/ and v2/
-  def testProject(base: File) =
-    Project("test-" + base.name, base).disablePlugins(BintrayPlugin).settings(testProjectSettings).configs(V1, V2)
+  private def testProject(base: File) =
+    Project(s"test-${base.name}", base).disablePlugins(BintrayPlugin).settings(testProjectSettings).configs(V1, V2)
 
-  // sets the source directory in this configuration to be: testN / vN
-  // scalaSource is the setting key that defines the directory for Scala sources
-  // configuration gets the current configuration
-  val shortSourceDir = scalaSource := baseDirectory.value / configuration.value.name.toLowerCase
+  // The settings for the V1 and V2 configurations (e.g. add compile and package).
+  private val testPerConfigSettings = Def.settings(
+    Defaults.configSettings, // use the normal per-configuration settings
+    // but modify the source directory to be just V1/ instead of src/V1/scala/
+    // scalaSource is the setting key that defines the directory for Scala sources
+    // configuration gets the current configuration
+    scalaSource := baseDirectory.value / configuration.value.name.toLowerCase,
+  )
 
-  // these are settings defined for each configuration (V1 and V2).
-  // We use the normal per-configuration settings, but modify the source directory to be just V1/ instead of src/V1/scala/
-  val perConfig = Defaults.configSettings :+ shortSourceDir
-
-  val runTest = Def.task {
-    val proj = thisProjectRef.value // gives us the ProjectRef this task is defined in
+  private val runFunctionalTest = Def.task {
     runCollectProblemsTest(
-      (fullClasspath in (functionalTests, Compile)).value, // the test classpath from the functionalTest project for the test
-      (scalaInstance in functionalTests).value, // get a reference to the already loaded Scala classes so we get the advantage of a warm jvm
+      (functionalTests / Compile / fullClasspath).value, // the test classpath from the functionalTest project for the test
+      (functionalTests / scalaInstance).value, // get a reference to the already loaded Scala classes so we get the advantage of a warm jvm
       streams.value,
-      proj.project,
-      (packageBin in V1).value, // package the V1 sources and get the configuration used
-      (packageBin in V2).value, // same for V2
+      thisProjectRef.value.project,
+      (V1 / packageBin).value, // package the V1 sources and get the configuration used
+      (V2 / packageBin).value, // same for V2
       baseDirectory.value,
       scalaVersion.value,
       null,
     )
   }
 
-  val testProjectSettings = Def.settings(
+  private val testProjectSettings = Def.settings(
     resolvers += "scala-pr-validation-snapshots" at "https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/",
     scalaVersion := testScalaVersion.value,
     crossScalaVersions := Seq("2.12.8", "2.13.0"),
-    inConfig(V1)(perConfig), // add compile/package for the V1 sources
-    inConfig(V2)(perConfig), // add compile/package for the V2 sources
-    test := runTest.value,
+    inConfig(V1)(testPerConfigSettings),
+    inConfig(V2)(testPerConfigSettings),
+    test := runFunctionalTest.value,
   )
 
-  def runCollectProblemsTest(
+  private def runCollectProblemsTest(
       cp: Classpath,
       si: ScalaInstance,
       streams: TaskStreams,
       testName: String,
-      v1: File,
-      v2: File,
+      oldJarOrDir: File,
+      newJarOrDir: File,
       projectPath: File,
-      scalaV: String,
+      scalaVersion: String,
       filterPath: String,
   ): Unit = {
     val urls = Attributed.data(cp).map(_.toURI.toURL).toArray
@@ -142,7 +137,7 @@ object TestsPlugin extends AutoPlugin {
       val p = projectPath / "problems.txt"
       val p212 = projectPath / "problems-2.12.txt"
       val p213 = projectPath / "problems-2.13.txt"
-      scalaV.take(4) match {
+      scalaVersion.take(4) match {
         case "2.13" if p213.exists() => p213
         case "2.13" if p212.exists() => p212
         case "2.12" if p212.exists() => p212
@@ -152,40 +147,43 @@ object TestsPlugin extends AutoPlugin {
 
     try {
       import scala.language.reflectiveCalls
-      testRunner.runTest(testClasspath, testName, v1.getAbsolutePath, v2.getAbsolutePath,
+      testRunner.runTest(testClasspath, testName, oldJarOrDir.getAbsolutePath, newJarOrDir.getAbsolutePath,
         oracleFile.getAbsolutePath, filterPath)
-      streams.log.info("Test '" + testName + "' succeeded.")
+      streams.log.info(s"Test '$testName' succeeded.")
     } catch {
       case e: Exception => sys.error(e.toString)
     }
   }
 
-  def getArtifact(depResolver: DependencyResolution, m: ModuleID, s: TaskStreams): File = {
+  private def getArtifact(depResolver: DependencyResolution, m: ModuleID, log: Logger): File = {
     val md = depResolver.wrapDependencyInModule(m)
     val updateConf = UpdateConfiguration().withLogging(UpdateLogging.DownloadOnly)
-    depResolver.update(md, updateConf, UnresolvedWarningConfiguration(), s.log) match {
+    depResolver.update(md, updateConf, UnresolvedWarningConfiguration(), log) match {
       case Left(unresolvedWarning) =>
-        import sbt.util.ShowLines._
-        unresolvedWarning.lines.foreach(s.log.warn(_))
+        import ShowLines._
+        unresolvedWarning.lines.foreach(log.warn(_))
         throw unresolvedWarning.resolveException
       case Right(updateReport) =>
-        val allFiles =
-          for {
-            conf <- updateReport.configurations
-            module <- conf.modules
-            (artifact, file) <- module.artifacts
-            if artifact.name == m.name
-          } yield file
+        val allFiles = for {
+          conf <- updateReport.configurations
+          module <- conf.modules
+          (artifact, file) <- module.artifacts
+          if artifact.name == m.name
+        } yield file
 
         allFiles.headOption getOrElse sys.error(s"Could not resolve artifact: $m")
     }
   }
 
-  def dependOnAll(f: ProjectRef => TaskKey[Unit]): Def.Initialize[Task[Unit]] = Def.taskDyn {
+  private def dependOnAll(f: ProjectRef => TaskKey[Unit]): Def.Initialize[Task[Unit]] = Def.taskDyn {
     val proj = thisProjectRef.value
     val structure = Project.structure(state.value)
     val allProjects = structure.allProjectRefs(proj.build).filter(_ != proj) // exclude self
     val allTasks = allProjects.flatMap(p => f(p).get(structure.data))
     Def.task(allTasks.join.map(_ => ()).value)
+  }
+
+  private def dirContaining(oracleFilename: String): FileFilter = {
+    DirectoryFilter && new SimpleFileFilter(_.list.contains(oracleFilename))
   }
 }


### PR DESCRIPTION
Instead of taking the first method which "matches type" (which actually 
means "has the same parameters") to check whether the result types also 
match, check them all.

The impact is visible in the integration test changes: ZipArchive's 
underlyingSource is "just" a (generic) signature problem, not a result type
problem.  Specifically it still returns a scala.Some, except it's a:

> ()Lscala/Some<Lscala/reflect/io/AbstractFile;>; rather than
()Lscala/Some<Lscala/reflect/io/ZipArchive;>;

... preceeded by a CollectProblemsTest improvement, a functional test setup fix & cleanup.