### PR TITLE
Move ConstantPool out of ClassfileParser

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileParser.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileParser.scala
@@ -6,9 +6,7 @@
 package com.typesafe.tools.mima.core
 
 import java.io.IOException
-import java.nio.charset.StandardCharsets
 
-import scala.annotation.switch
 import scala.collection.mutable.ArrayBuffer
 
 import scala.tools.nsc.symtab.classfile.ClassfileConstants._
@@ -28,7 +26,7 @@ final class ClassfileParser(definitions: Definitions) {
 
   protected def parseAll(clazz: ClassInfo): Unit = {
     parseHeader(clazz)
-    thepool = new ConstantPool
+    thepool = new ConstantPool(definitions, in)
     parseClass(clazz)
   }
 
@@ -40,93 +38,6 @@ final class ClassfileParser(definitions: Definitions) {
                             + ", should be 0x" + JAVA_MAGIC.toHexString)
     in.nextChar.toInt // minorVersion
     in.nextChar.toInt // majorVersion
-  }
-
-  class ConstantPool {
-    val length = in.nextChar
-    private val starts = new Array[Int](length)
-    private val values = new Array[AnyRef](length)
-    private val internalized = new Array[String](length)
-
-    { var i = 1
-      while (i < length) {
-        starts(i) = in.bp
-        i += 1
-        (in.nextByte.toInt: @switch) match {
-          case CONSTANT_UTF8 | CONSTANT_UNICODE =>
-            in.skip(in.nextChar)
-          case CONSTANT_CLASS | CONSTANT_STRING | CONSTANT_METHODTYPE
-             | CONSTANT_MODULE | CONSTANT_PACKAGE =>
-            in.skip(2)
-          case CONSTANT_METHODHANDLE =>
-            in.skip(3)
-          case CONSTANT_FIELDREF | CONSTANT_METHODREF | CONSTANT_INTFMETHODREF
-             | CONSTANT_NAMEANDTYPE | CONSTANT_INTEGER | CONSTANT_FLOAT
-             | CONSTANT_INVOKEDYNAMIC =>
-            in.skip(4)
-          case CONSTANT_LONG | CONSTANT_DOUBLE =>
-            in.skip(8)
-            i += 1
-          case _ =>
-            errorBadTag(in.bp - 1)
-        }
-      }
-    }
-
-    /** Return the name found at given index. */
-    def getName(index: Int): String = {
-      if (index <= 0 || length <= index) errorBadIndex(index)
-      var name = values(index).asInstanceOf[String]
-      if (name eq null) {
-        val start = starts(index)
-        if (in.buf(start).toInt != CONSTANT_UTF8) errorBadTag(start)
-        name = new String(in.buf, start + 3, in.getChar(start + 1), StandardCharsets.UTF_8)
-        values(index) = name
-      }
-      name
-    }
-
-    /** Return the name found at given index in the constant pool, with '/' replaced by '.'. */
-    def getExternalName(index: Int): String = {
-      if (index <= 0 || length <= index) errorBadIndex(index)
-      if (internalized(index) eq null) {
-        internalized(index) = getName(index).replace('/', '.')
-      }
-      internalized(index)
-    }
-
-    def getClassInfo(index: Int): ClassInfo = {
-      if (index <= 0 || length <= index) errorBadIndex(index)
-      var c = values(index).asInstanceOf[ClassInfo]
-      if (c eq null) {
-        val start = starts(index)
-        if (in.buf(start).toInt != CONSTANT_CLASS) errorBadTag(start)
-        val name = getExternalName(in.getChar(start + 1))
-        c = definitions.fromName(name)
-        values(index) = c
-      }
-      c
-    }
-
-    /** Return the external name of the class info structure found at 'index'.
-     *  Use 'getClassSymbol' if the class is sure to be a top-level class.
-     */
-    def getClassName(index: Int): String = {
-      val start = starts(index)
-      if (in.buf(start).toInt != CONSTANT_CLASS) errorBadTag(start)
-      getExternalName(in.getChar(start + 1))
-    }
-
-    def getSuperClass(index: Int): ClassInfo =
-      if (index == 0) ClassInfo.ObjectClass else getClassInfo(index)
-
-    /** Throws an exception signaling a bad constant index. */
-    private def errorBadIndex(index: Int) =
-      throw new RuntimeException("bad constant pool index: " + index + " at pos: " + in.bp)
-
-    /** Throws an exception signaling a bad tag at given address. */
-    private def errorBadTag(start: Int) =
-      throw new RuntimeException("bad constant pool tag " + in.buf(start) + " at byte " + start)
   }
 
   def parseMembers(clazz: ClassInfo): Members = {

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ConstantPool.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ConstantPool.scala
@@ -1,0 +1,96 @@
+package com.typesafe.tools.mima.core
+
+import java.nio.charset.StandardCharsets
+
+import scala.annotation.switch
+
+import scala.tools.nsc.symtab.classfile.ClassfileConstants._
+
+private[core] final class ConstantPool(definitions: Definitions, in: BufferReader) {
+  import ClassfileParser._
+
+  val length = in.nextChar
+  private val starts = new Array[Int](length)
+  private val values = new Array[AnyRef](length)
+  private val internalized = new Array[String](length)
+
+  { var i = 1
+    while (i < length) {
+      starts(i) = in.bp
+      i += 1
+      (in.nextByte.toInt: @switch) match {
+        case CONSTANT_UTF8 | CONSTANT_UNICODE =>
+          in.skip(in.nextChar)
+        case CONSTANT_CLASS | CONSTANT_STRING | CONSTANT_METHODTYPE
+           | CONSTANT_MODULE | CONSTANT_PACKAGE =>
+          in.skip(2)
+        case CONSTANT_METHODHANDLE =>
+          in.skip(3)
+        case CONSTANT_FIELDREF | CONSTANT_METHODREF | CONSTANT_INTFMETHODREF
+           | CONSTANT_NAMEANDTYPE | CONSTANT_INTEGER | CONSTANT_FLOAT
+           | CONSTANT_INVOKEDYNAMIC =>
+          in.skip(4)
+        case CONSTANT_LONG | CONSTANT_DOUBLE =>
+          in.skip(8)
+          i += 1
+        case _ =>
+          errorBadTag(in.bp - 1)
+      }
+    }
+  }
+
+  /** Return the name found at given index. */
+  def getName(index: Int): String = {
+    if (index <= 0 || length <= index) errorBadIndex(index)
+    var name = values(index).asInstanceOf[String]
+    if (name eq null) {
+      val start = starts(index)
+      if (in.buf(start).toInt != CONSTANT_UTF8) errorBadTag(start)
+      name = new String(in.buf, start + 3, in.getChar(start + 1), StandardCharsets.UTF_8)
+      values(index) = name
+    }
+    name
+  }
+
+  /** Return the name found at given index in the constant pool, with '/' replaced by '.'. */
+  def getExternalName(index: Int): String = {
+    if (index <= 0 || length <= index) errorBadIndex(index)
+    if (internalized(index) eq null) {
+      internalized(index) = getName(index).replace('/', '.')
+    }
+    internalized(index)
+  }
+
+  def getClassInfo(index: Int): ClassInfo = {
+    if (index <= 0 || length <= index) errorBadIndex(index)
+    var c = values(index).asInstanceOf[ClassInfo]
+    if (c eq null) {
+      val start = starts(index)
+      if (in.buf(start).toInt != CONSTANT_CLASS) errorBadTag(start)
+      val name = getExternalName(in.getChar(start + 1))
+      c = definitions.fromName(name)
+      values(index) = c
+    }
+    c
+  }
+
+  /** Return the external name of the class info structure found at 'index'.
+   *  Use 'getClassSymbol' if the class is sure to be a top-level class.
+   */
+  def getClassName(index: Int): String = {
+    val start = starts(index)
+    if (in.buf(start).toInt != CONSTANT_CLASS) errorBadTag(start)
+    getExternalName(in.getChar(start + 1))
+  }
+
+  def getSuperClass(index: Int): ClassInfo =
+    if (index == 0) ClassInfo.ObjectClass else getClassInfo(index)
+
+  /** Throws an exception signaling a bad constant index. */
+  private def errorBadIndex(index: Int) =
+    throw new RuntimeException("bad constant pool index: " + index + " at pos: " + in.bp)
+
+  /** Throws an exception signaling a bad tag at given address. */
+  private def errorBadTag(start: Int) =
+    throw new RuntimeException("bad constant pool tag " + in.buf(start) + " at byte " + start)
+}


### PR DESCRIPTION
Even though it's intimately related to the class file parser, it's a
large enough piece of behaviour, which is already a distinct class, that
it's reasonable to think about dealing with as a standalone "thing".