### PR TITLE
Sort, group & cleanup Problems

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/MemberInfo.scala
@@ -33,8 +33,10 @@ private[mima] final class FieldInfo(owner: ClassInfo, bytecodeName: String, flag
 private[mima] final class MethodInfo(owner: ClassInfo, bytecodeName: String, flags: Int, descriptor: String)
     extends MemberInfo(owner, bytecodeName, flags, descriptor)
 {
-  def methodString: String      = s"$shortMethodString in ${owner.classString}"
-  def shortMethodString: String = {
+  def methodString: String         = s"$shortMethodString in ${owner.classString}"
+  def abstractMethodString: String = s"$abstractPrefix$methodString"
+  def abstractPrefix               = if (isDeferred && !owner.isTrait) "abstract " else ""
+  def shortMethodString: String    = {
     val prefix = if (hasSyntheticName) if (isExtensionMethod) "extension " else "synthetic " else ""
     val deprecated = if (isDeprecated) "deprecated " else ""
     s"$prefix${deprecated}method $decodedName$tpe"

--- a/core/src/test/scala/com/typesafe/tools/mima/core/ProblemFiltersSpec.scala
+++ b/core/src/test/scala/com/typesafe/tools/mima/core/ProblemFiltersSpec.scala
@@ -4,8 +4,6 @@ import org.scalatest._
 import org.scalatest.prop.TableDrivenPropertyChecks
 
 class ProblemFiltersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
-  import ProblemFiltersSpec._
-
   val filters = Table(
     ("filter", "problem", "realProblem"),
     (ProblemFilters.exclude[Problem]("impl.Http"), problem("impl.Http"),  false),
@@ -24,11 +22,5 @@ class ProblemFiltersSpec extends WordSpec with TableDrivenPropertyChecks with Ma
     }
   }
 
-}
-
-object ProblemFiltersSpec {
-  def problem(name: String) = new TemplateProblem(NoClass) {
-    override def description: (String) => String = ???
-    override def matchName: Some[String] = Some(name)
-  }
+  private def problem(name: String) = FinalClassProblem(new SyntheticClassInfo(NoPackageInfo, name))
 }

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -45,8 +45,10 @@ object MimaSettings {
 
       // Dropped deprecated method
       ProblemFilters.exclude[DirectMissingMethodProblem]("*mima.core.ProblemFilters.excludePackage"),
-      // Changes to the members of the *Problems classes
+      // Changes to the members of the *Problem classes
       ProblemFilters.exclude[MemberProblem]("*mima.core.*Problem.*"),
+      // *Problem classes made final
+      ProblemFilters.exclude[FinalClassProblem]("*mima.core.*Problem"),
       // Dropped unused methods on classes in the hierarchy of the *Problem classes
       ProblemFilters.exclude[DirectMissingMethodProblem]("*mima.core.ProblemRef.*"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("*mima.core.TemplateRef.*"),


### PR DESCRIPTION
Using pattern matching to define "description" moves the implementation
a little away from each Problem class definition.  However, overall the
file shrinks and now the problem descriptions can be made more uniform
by comparison.