### PR TITLE
Set the default scalaVersion back to 2.12.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ inThisBuild(Seq(
   scmInfo := Some(ScmInfo(url("https://github.com/lightbend/mima"), "scm:git:git@github.com:lightbend/mima.git")),
   git.gitTagToVersionNumber := (tag => if (tag matches "[0.9]+\\..*") Some(tag) else None),
   git.useGitDescribe := true,
+  scalaVersion := scala212.value,
   scalaVersion := sys.props.getOrElse("mima.buildScalaVersion", scalaVersion.value),
   scalacOptions := Seq("-feature", "-deprecation", "-Xlint"),
 ))


### PR DESCRIPTION
With sbt-travisci it picked 2.13.0, which doesn't work nicely as the
sbtplugin doesn't support it.