### PR TITLE
downgrade ScalaTest to 3.0.x, for community build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ val core = project.disablePlugins(BintrayPlugin).settings(
   name := "mima-core",
   libraryDependencies ++= Seq(
     "org.scala-lang" %  "scala-compiler" % scalaVersion.value,
-    "org.scalatest"  %% "scalatest"      % "3.1.0-SNAP13" % Test,
+    "org.scalatest"  %% "scalatest"      % "3.0.8" % Test,
   ),
   MimaSettings.mimaSettings,
 )

--- a/core/src/test/scala/com/typesafe/tools/mima/core/ProblemFiltersSpec.scala
+++ b/core/src/test/scala/com/typesafe/tools/mima/core/ProblemFiltersSpec.scala
@@ -2,9 +2,9 @@ package com.typesafe.tools.mima.core
 
 import org.scalatest.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.WordSpec
 
-final class ProblemFiltersSpec extends AnyWordSpec with TableDrivenPropertyChecks with Matchers {
+final class ProblemFiltersSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
   val filters = Table(
     ("filter", "problem", "realProblem"),
     (ProblemFilters.exclude[Problem]("impl.Http"), problem("impl.Http"),  false),

--- a/core/src/test/scala/com/typesafe/tools/mima/core/ProblemReportingSpec.scala
+++ b/core/src/test/scala/com/typesafe/tools/mima/core/ProblemReportingSpec.scala
@@ -3,9 +3,9 @@ package com.typesafe.tools.mima.core
 import com.typesafe.tools.mima.core.util.log.Logging
 
 import org.scalatest.Matchers
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.WordSpec
 
-final class ProblemReportingSpec extends AnyWordSpec with Matchers {
+final class ProblemReportingSpec extends WordSpec with Matchers {
   import ProblemReportingSpec._
 
   "problem" should {


### PR DESCRIPTION
I think we had moved to 3.1.x because there was an interval when
3.0.x wasn't available for whatever Scala 2.13 prerelease is current
at the time. that consideration no longer applies.

in the community build, we're still on ScalaTest 3.0 (since 3.1 isn't
final yet), so I'd rather do the downgrade here for now, rather than
have to freeze mima in the community build (which is what we've done
with some other projects that have moved to 3.1)