### PR TITLE
Use <missing> rather than [N/A] for missing signatures

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/Problems.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Problems.scala
@@ -41,7 +41,7 @@ sealed abstract class Problem extends ProblemRef {
     case ReversedMissingMethodProblem(ref)                       => s"${ref.abstractMethodString} is present only in $affectedVersion version"
     case FinalMethodProblem(ref)                                 => s"${ref.methodString} is declared final in $affectedVersion version"
     case IncompatibleResultTypeProblem(ref, newmeth)             => s"${ref.methodString} has a different result type in $affectedVersion version, where it is ${newmeth.tpe.resultType} rather than ${ref.tpe.resultType}"
-    case IncompatibleSignatureProblem(ref, newmeth)              => s"${ref.methodString} has a different signature in $affectedVersion version, where it is ${orNA(newmeth.signature)} rather than ${orNA(ref.signature)}"
+    case IncompatibleSignatureProblem(ref, newmeth)              => s"${ref.methodString} has a different signature in $affectedVersion version, where it is ${orMIA(newmeth.signature)} rather than ${orMIA(ref.signature)}"
     case DirectAbstractMethodProblem(ref)                        => s"abstract ${ref.methodString} does not have a correspondent in $affectedVersion version"
     case ReversedAbstractMethodProblem(ref)                      => s"in $affectedVersion version there is abstract ${ref.methodString}, which does not have a correspondent"
     case UpdateForwarderBodyProblem(ref)                         => s"in $affectedVersion version, classes mixing ${ref.owner.fullName} needs to update body of ${ref.shortMethodString}"
@@ -49,7 +49,7 @@ sealed abstract class Problem extends ProblemRef {
   }
 
   // a method that takes no parameters and returns Object can have no signature
-  private def orNA(s: String) = if (s.isEmpty) "[N/A]" else s
+  private def orMIA(s: String) = if (s.isEmpty) "<missing>" else s
 }
 
 // Template problems

--- a/functional-tests/src/test/class-constructor-generics-nok/problems.txt
+++ b/functional-tests/src/test/class-constructor-generics-nok/problems.txt
@@ -1,3 +1,3 @@
 method source()scala.Tuple2 in class OptionPane has a different signature in new version, where it is ()Lscala/Tuple2<LMyPane<TA;>;Ljava/lang/String;>; rather than ()Lscala/Tuple2<Ljavax/swing/JOptionPane;Ljava/lang/String;>;
-method show()java.lang.Object in class OptionPane has a different signature in new version, where it is ()TA; rather than [N/A]
+method show()java.lang.Object in class OptionPane has a different signature in new version, where it is ()TA; rather than <missing>
 method this(scala.Tuple2)Unit in class OptionPane has a different signature in new version, where it is (Lscala/Tuple2<LMyPane<TA;>;Ljava/lang/String;>;)V rather than (Lscala/Tuple2<Ljavax/swing/JOptionPane;Ljava/lang/String;>;)V

--- a/functional-tests/src/test/class-method-generics-nok/problems.txt
+++ b/functional-tests/src/test/class-method-generics-nok/problems.txt
@@ -1,2 +1,12 @@
 method genericWithChangingName()scala.Option in class A has a different signature in new version, where it is <T:Ljava/lang/Object;>()Lscala/Option<TT;>; rather than <U:Ljava/lang/Object;>()Lscala/Option<TU;>;
 method backwardsCompatibleNarrowing()scala.Option in class A has a different signature in new version, where it is ()Lscala/Option<Ljava/lang/String;>; rather than ()Lscala/Option<Ljava/lang/Object;>;
+#
+method cov1()java.lang.Object in class Api has a different signature in new version, where it is <A:Ljava/lang/Object;>()TA; rather than <missing>
+method cov2()java.lang.Object in class Api has a different signature in new version, where it is <missing> rather than <T:Ljava/lang/Object;>()TT;
+method con1(java.lang.Object)Unit in class Api has a different signature in new version, where it is <A:Ljava/lang/Object;>(TA;)V rather than <missing>
+method con2(java.lang.Object)Unit in class Api has a different signature in new version, where it is <missing> rather than <T:Ljava/lang/Object;>(TT;)V
+#
+method cov1()java.lang.Object in class Abi has a different signature in new version, where it is <A:Ljava/lang/Object;>()TA; rather than <missing>
+method cov2()java.lang.Object in class Abi has a different signature in new version, where it is <missing> rather than <T:Ljava/lang/Object;>()TT;
+method con1(java.lang.Object)Unit in class Abi has a different signature in new version, where it is <A:Ljava/lang/Object;>(TA;)V rather than <missing>
+method con2(java.lang.Object)Unit in class Abi has a different signature in new version, where it is <missing> rather than <T:Ljava/lang/Object;>(TT;)V

--- a/functional-tests/src/test/class-method-generics-nok/v1/A.scala
+++ b/functional-tests/src/test/class-method-generics-nok/v1/A.scala
@@ -2,3 +2,19 @@ class A {
   def genericWithChangingName[U]: Option[U] = ???
   def backwardsCompatibleNarrowing: Option[Any] = ???
 }
+
+final class Api {
+  def cov1(): Any         = ???
+  def cov2[T](): T        = ???
+
+  def con1(x: Any): Unit  = ()
+  def con2[T](x: T): Unit = ()
+}
+
+abstract class Abi {
+  def cov1(): Any
+  def cov2[T](): T
+
+  def con1(x: Any): Unit
+  def con2[T](x: T): Unit
+}

--- a/functional-tests/src/test/class-method-generics-nok/v2/A.scala
+++ b/functional-tests/src/test/class-method-generics-nok/v2/A.scala
@@ -2,3 +2,19 @@ class A {
   def genericWithChangingName[T]: Option[T] = ???
   def backwardsCompatibleNarrowing: Option[String] = ???
 }
+
+final class Api {
+  def cov1[A](): A        = ??? // OK
+  def cov2(): Any         = ??? // KO
+
+  def con1[A](x: A): Unit = () // KO
+  def con2(x: Any): Unit  = () // OK
+}
+
+abstract class Abi {
+  def cov1[A](): A // KO
+  def cov2(): Any  // OK
+
+  def con1[A](x: A): Unit // OK
+  def con2(x: Any): Unit  // KO
+}


### PR DESCRIPTION
Also adds a API vs ABI example showing how we can't assume that losing a signature is safe.