### PR TITLE
Add test for public method becomes private[lib]

### DIFF
--- a/functional-tests/src/test/public-method-becomes-package-private-ok/v1/A.scala
+++ b/functional-tests/src/test/public-method-becomes-package-private-ok/v1/A.scala
@@ -1,0 +1,8 @@
+package bar
+class A[T](t: T)
+object A {
+  def foo[T](implicit x: T): A[T] = ???
+  def foo[T](implicit x: T, y: T): A[T] = ???
+  def foo[T](f: T => T): A[T] = ???
+  def foo[T](f: (T, T) => T): A[T] = ???
+}

--- a/functional-tests/src/test/public-method-becomes-package-private-ok/v2/A.scala
+++ b/functional-tests/src/test/public-method-becomes-package-private-ok/v2/A.scala
@@ -1,0 +1,8 @@
+package bar
+class A[T](t: T)
+object A {
+  def foo[T](implicit x: T): A[T] = ???
+  private[bar] def foo[T](implicit x: T, y: T): A[T] = ???
+  def foo[T](f: T => T): A[T] = ???
+  def foo[T](f: (T, T) => T): A[T] = ???
+}


### PR DESCRIPTION
This came up as an issue when updating to MiMa 0.5.0 in ScalaCheck, see https://github.com/typelevel/scalacheck/issues/509 