### PR TITLE
Fix warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,16 @@ val core = project.disablePlugins(BintrayPlugin).settings(
     "org.scalatest"  %% "scalatest"      % "3.0.8" % Test,
   ),
   MimaSettings.mimaSettings,
+  apiMappings ++= {
+    // WORKAROUND https://github.com/scala/bug/issues/9311
+    // from https://stackoverflow.com/a/31322970/463761
+    sys.props("sun.boot.class.path")
+      .split(java.io.File.pathSeparator)
+      .collectFirst { case str if str.endsWith(java.io.File.separator + "rt.jar") =>
+        file(str) -> url("http://docs.oracle.com/javase/8/docs/api/index.html")
+      }
+      .toMap
+  },
   publishTo := Some(if (isSnapshot.value) Opts.resolver.sonatypeSnapshots else Opts.resolver.sonatypeStaging),
 )
 

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ProblemFilters.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ProblemFilters.scala
@@ -26,7 +26,7 @@ object ProblemFilters {
    *
    *  The problemName is name of a class corresponding to a problem like `AbstractMethodProblem`.
    *
-   *  @throws ClassNotFoundException if the class corresponding to the problem cannot be located
+   *  @throws java.lang.ClassNotFoundException if the class corresponding to the problem cannot be located
    */
   def exclude(problemName: String, name: String): ProblemFilter = {
     val problemClass: Class[_ <: ProblemRef] =

--- a/core/src/main/scala/com/typesafe/tools/mima/core/package.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/package.scala
@@ -1,6 +1,7 @@
 package com.typesafe.tools.mima
 
 import scala.tools.nsc.util.ClassPath
+import scala.tools.nsc.CloseableRegistry
 import scala.tools.nsc.classpath.{AggregateClassPath, ClassPathFactory}
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.util.PathResolver
@@ -10,7 +11,7 @@ package object core {
   type ProblemFilter = Problem => Boolean
 
   def resolveClassPath(): ClassPath =
-    AggregateClassPath.createAggregate(new PathResolver(Config.settings).containers: _*)
+    AggregateClassPath.createAggregate(new PathResolver(Config.settings, new CloseableRegistry).containers: _*)
 
   def definitionsPackageInfo(defs: Definitions): ConcretePackageInfo =
     new DefinitionsPackageInfo(defs)
@@ -29,13 +30,13 @@ package object core {
     cp.packagesIn(ClassPath.RootPackage).map(p => p.name -> new ConcretePackageInfo(pkg, cp, p.name, defs))
 
   def baseClassPath(cpString: String): ClassPath =
-    AggregateClassPath.createAggregate(new ClassPathFactory(Config.settings).classesInPath(cpString): _*)
+    AggregateClassPath.createAggregate(new ClassPathFactory(Config.settings, new CloseableRegistry).classesInPath(cpString): _*)
 
   def reporterClassPath(classpath: String): ClassPath =
-    AggregateClassPath.createAggregate(new ClassPathFactory(Config.settings).classesInPath(classpath): _*)
+    AggregateClassPath.createAggregate(new ClassPathFactory(Config.settings, new CloseableRegistry).classesInPath(classpath): _*)
 
   def dirClassPath(dir: AbstractFile): ClassPath =
-    ClassPathFactory.newClassPath(dir, Config.settings)
+    ClassPathFactory.newClassPath(dir, Config.settings, new CloseableRegistry)
 
   private[core] type Fields  = Members[FieldInfo]
   private[core] type Methods = Members[MethodInfo]

--- a/core/src/main/scala/com/typesafe/tools/mima/core/package.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/package.scala
@@ -1,7 +1,6 @@
 package com.typesafe.tools.mima
 
 import scala.tools.nsc.util.ClassPath
-import scala.tools.nsc.CloseableRegistry
 import scala.tools.nsc.classpath.{AggregateClassPath, ClassPathFactory}
 import scala.tools.nsc.io.AbstractFile
 import scala.tools.util.PathResolver
@@ -11,7 +10,7 @@ package object core {
   type ProblemFilter = Problem => Boolean
 
   def resolveClassPath(): ClassPath =
-    AggregateClassPath.createAggregate(new PathResolver(Config.settings, new CloseableRegistry).containers: _*)
+    AggregateClassPath.createAggregate(new PathResolver(Config.settings).containers: _*)
 
   def definitionsPackageInfo(defs: Definitions): ConcretePackageInfo =
     new DefinitionsPackageInfo(defs)
@@ -30,13 +29,13 @@ package object core {
     cp.packagesIn(ClassPath.RootPackage).map(p => p.name -> new ConcretePackageInfo(pkg, cp, p.name, defs))
 
   def baseClassPath(cpString: String): ClassPath =
-    AggregateClassPath.createAggregate(new ClassPathFactory(Config.settings, new CloseableRegistry).classesInPath(cpString): _*)
+    AggregateClassPath.createAggregate(new ClassPathFactory(Config.settings).classesInPath(cpString): _*)
 
   def reporterClassPath(classpath: String): ClassPath =
-    AggregateClassPath.createAggregate(new ClassPathFactory(Config.settings, new CloseableRegistry).classesInPath(classpath): _*)
+    AggregateClassPath.createAggregate(new ClassPathFactory(Config.settings).classesInPath(classpath): _*)
 
   def dirClassPath(dir: AbstractFile): ClassPath =
-    ClassPathFactory.newClassPath(dir, Config.settings, new CloseableRegistry)
+    ClassPathFactory.newClassPath(dir, Config.settings)
 
   private[core] type Fields  = Members[FieldInfo]
   private[core] type Methods = Members[MethodInfo]


### PR DESCRIPTION
I got the following warnings while releasing 0.6.1:

```
[warn] /d/mima/core/src/main/scala/com/typesafe/tools/mima/core/package.scala:13:40: constructor PathResolver in class PathResolver is deprecated (since 2.12.9): for bincompat in 2.12.x series
[warn]     AggregateClassPath.createAggregate(new PathResolver(Config.settings).containers: _*)
[warn]                                        ^
[warn] /d/mima/core/src/main/scala/com/typesafe/tools/mima/core/package.scala:32:40: constructor ClassPathFactory in class ClassPathFactory is deprecated (since 2.12.9): for bincompat in 2.12.x series
[warn]     AggregateClassPath.createAggregate(new ClassPathFactory(Config.settings).classesInPath(cpString): _*)
[warn]                                        ^
[warn] /d/mima/core/src/main/scala/com/typesafe/tools/mima/core/package.scala:35:40: constructor ClassPathFactory in class ClassPathFactory is deprecated (since 2.12.9): for bincompat in 2.12.x series
[warn]     AggregateClassPath.createAggregate(new ClassPathFactory(Config.settings).classesInPath(classpath): _*)
[warn]                                        ^
[warn] /d/mima/core/src/main/scala/com/typesafe/tools/mima/core/package.scala:38:22: method newClassPath in object ClassPathFactory is deprecated (since 2.12.9): for bincompat in 2.12.x series
[warn]     ClassPathFactory.newClassPath(dir, Config.settings)
[warn]                      ^
[warn] /d/mima/core/src/main/scala/com/typesafe/tools/mima/core/ProblemFilters.scala:24:3: Could not find any member to link for "ClassNotFoundException".
[warn]   /** Creates an exclude filter by taking the name of the problem and the name of a match
[warn]   ^
```