### PR TITLE
Drop building in Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,14 @@
 language: scala
 jdk: openjdk8
-scala:
-  - 2.12.10
-  - 2.13.1
+scala: 2.12.10
 
-script: sbt "++$TRAVIS_SCALA_VERSION mimaReportBinaryIssues" "++$TRAVIS_SCALA_VERSION test" "++$TRAVIS_SCALA_VERSION IntegrationTest/test"
+script: sbt mimaReportBinaryIssues test IntegrationTest/test
 
 jobs:
   include:
-  - { name: 2.12 testFunctional 2.11, script: sbt -Dmima.buildScalaVersion=2.12.10 -Dmima.testScalaVersion=2.11.12 testFunctional }
-  - { name: 2.12 testFunctional 2.12, script: sbt -Dmima.buildScalaVersion=2.12.10 -Dmima.testScalaVersion=2.12.10  testFunctional }
-  - { name: 2.12 testFunctional 2.13, script: sbt -Dmima.buildScalaVersion=2.12.10 -Dmima.testScalaVersion=2.13.1  testFunctional }
-  - { name: 2.13 testFunctional 2.11, script: sbt -Dmima.buildScalaVersion=2.13.1 -Dmima.testScalaVersion=2.11.12 testFunctional }
-  - { name: 2.13 testFunctional 2.12, script: sbt -Dmima.buildScalaVersion=2.13.1 -Dmima.testScalaVersion=2.12.10  testFunctional }
-  - { name: 2.13 testFunctional 2.13, script: sbt -Dmima.buildScalaVersion=2.13.1 -Dmima.testScalaVersion=2.13.1  testFunctional }
+  - { name: testFunctional 2.11, script: sbt -Dmima.testScalaVersion=2.11.12 testFunctional }
+  - { name: testFunctional 2.12, script: sbt -Dmima.testScalaVersion=2.12.10  testFunctional }
+  - { name: testFunctional 2.13, script: sbt -Dmima.testScalaVersion=2.13.1  testFunctional }
   - { name: scripted 1/2, script: sbt "scripted sbt-mima-plugin/*1of2" }
   - { name: scripted 2/2, script: sbt "scripted sbt-mima-plugin/*2of2" }
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,6 @@ inThisBuild(Seq(
   ),
   scmInfo := Some(ScmInfo(url("https://github.com/lightbend/mima"), "scm:git:git@github.com:lightbend/mima.git")),
   dynverVTagPrefix := false,
-  scalaVersion := scala212.value,
-  scalaVersion := sys.props.getOrElse("mima.buildScalaVersion", scalaVersion.value),
   scalacOptions := Seq("-feature", "-deprecation", "-Xlint"),
 //resolvers += stagingResolver,
 ))
@@ -51,7 +49,6 @@ val core = project.disablePlugins(BintrayPlugin).settings(
 
 val sbtplugin = project.enablePlugins(SbtPlugin).dependsOn(core).settings(
   name := "sbt-mima-plugin",
-  crossScalaVersions := Seq(scala212.value),
   // drop the previous value to drop running Test/compile
   scriptedDependencies := Def.task(()).dependsOn(publishLocal, publishLocal in core).value,
   scriptedLaunchOpts += s"-Dplugin.version=${version.value}",

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -12,15 +12,10 @@ object MimaSettings {
   // clear out mimaBinaryIssueFilters when changing this
   val mimaPreviousVersion = "0.6.1"
 
-  private val isScala213OrLater =
-    Def.setting(VersionNumber(scalaVersion.value).matchesSemVer(SemanticSelector(">=2.13")))
-
   val mimaSettings = Def.settings (
     mimaPreviousArtifacts := Set(pluginProjectID.value.withRevision(mimaPreviousVersion)
       .withExplicitArtifacts(Vector()) // defaultProjectID uses artifacts.value which breaks it =/
     ),
-    mimaPreviousArtifacts := (if (isScala213OrLater.value) Set() else mimaPreviousArtifacts.value),
-    ThisBuild / mimaFailOnNoPrevious := !isScala213OrLater.value,
     mimaBinaryIssueFilters ++= Seq(
       // The main public API is:
       // * com.typesafe.tools.mima.plugin.MimaPlugin


### PR DESCRIPTION
This drops the setup & testing of MiMa using Scala 2.13.

The reason is that there is no need for this.  MiMa is by-and-large
consumed via its sbt plugins, which is not 1.x only.  sbt 1.x will
always be Scala 2.12 only, and there are not real plans for sbt 2.x.
Therefore we can stop building with Scala 2.13.

Note that MiMa continues to support verifying the binary compatibility
of Scala 2.11-2.13 projects - that support is crucial and not going
anywhere.