### PR TITLE
Speed-up scripted

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,8 +52,10 @@ val core = project.disablePlugins(BintrayPlugin).settings(
 val sbtplugin = project.enablePlugins(SbtPlugin).dependsOn(core).settings(
   name := "sbt-mima-plugin",
   crossScalaVersions := Seq(scala212.value),
-  scriptedDependencies := scriptedDependencies.dependsOn(publishLocal in core).value,
-  scriptedLaunchOpts += "-Dplugin.version=" + version.value,
+  // drop the previous value to drop running Test/compile
+  scriptedDependencies := Def.task(()).dependsOn(publishLocal, publishLocal in core).value,
+  scriptedLaunchOpts += s"-Dplugin.version=${version.value}",
+  scriptedLaunchOpts += s"-Dsbt.boot.directory=${file(sys.props("user.home")) / ".sbt" / "boot"}",
   MimaSettings.mimaSettings,
   bintrayOrganization := Some("typesafe"),
   bintrayReleaseOnPublish := false,


### PR DESCRIPTION
Defining "sbt.boot.directory" makes the scripted test (re)use the same 
user-shared compiler bridge instead of compiling one every time.

Also drop running "Test / compile".

~Builds on #400 just because it's modifying an adjacent line in build.sbt.~