### PR TITLE
Drop Config.baseClassPath/baseDefinitions (var!)

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
@@ -8,10 +8,14 @@ import com.typesafe.tools.mima.core.util.log.ConsoleLogging
 object ClassInfo {
   def formatClassName(str: String) = NameTransformer.decode(str).replace('$', '#')
 
-  /** We assume there can be only one java.lang.Object class, and that comes from the configuration
-   *  class path.
+  /** We assume there can be only one java.lang.Object class,
+   *  and that comes from the configuration class path.
    */
-  lazy val ObjectClass = Config.baseDefinitions.ObjectClass
+  lazy val ObjectClass = {
+    val baseClassPath = DeprecatedPathApis.newPathResolver(Config.settings).result
+    val baseDefinitions = new Definitions(None, baseClassPath)
+    baseDefinitions.ObjectClass
+  }
 }
 
 /** A placeholder class info for a class that is not found on the classpath or in a given

--- a/core/src/main/scala/com/typesafe/tools/mima/core/Config.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Config.scala
@@ -1,18 +1,11 @@
 package com.typesafe.tools.mima.core
 
 import scala.tools.nsc.Settings
-import scala.tools.nsc.classpath.AggregateClassPath
-import scala.tools.nsc.util.ClassPath
 
 object Config {
   val settings: Settings = new Settings
   val verbose: Boolean   = settings.verbose.value
   val debug: Boolean     = settings.debug.value
-
-  var baseClassPath: ClassPath =
-    AggregateClassPath.createAggregate(DeprecatedPathApis.newPathResolver(settings).containers: _*)
-
-  lazy val baseDefinitions: Definitions = new Definitions(None, baseClassPath)
 
   def fatal(msg: String): Nothing = {
     Console.err.println(msg)

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
@@ -3,19 +3,15 @@ package com.typesafe.tools.mima.lib
 import java.io.File
 
 import com.typesafe.config.ConfigFactory
-import com.typesafe.tools.mima.core.{ Config, Problem, aggregateClassPath }
+import com.typesafe.tools.mima.core.{ Problem, aggregateClassPath }
 
 import scala.io.Source
-import scala.tools.nsc.classpath.AggregateClassPath
 
 object CollectProblemsTest {
 
   // Called via reflection from TestsPlugin
   def runTest(testClasspath: Array[File], testName: String, oldJarOrDir: File, newJarOrDir: File, baseDir: File, scalaVersion: String): Unit = {
-    val testClassPath = aggregateClassPath(testClasspath)
-    Config.baseClassPath = AggregateClassPath.createAggregate(testClassPath, Config.baseClassPath)
-
-    val mima = new MiMaLib(Config.baseClassPath)
+    val mima = new MiMaLib(aggregateClassPath(testClasspath))
 
     // SUT
     val allProblems = mima.collectProblems(oldJarOrDir, newJarOrDir)


### PR DESCRIPTION
That classpath is only used to define ClassInfo.ObjectClass, so:

  1. don't make it a var and redefine it
  2. localise its usage