### PR TITLE
Reimplement problem discovery for dropped overload

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodChecker.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/lib/analyze/method/MethodChecker.scala
@@ -9,25 +9,25 @@ private[analyze] abstract class BaseMethodChecker extends Checker[MethodInfo, Cl
 
   protected val rules = Seq(AccessModifier, FinalModifier, AbstractModifier, JavaStatic)
 
-  protected def check(method: MethodInfo, newclazz: ClassInfo, methsLookup: ClassInfo => Iterator[MethodInfo]): Option[Problem] = {
-    val meths = methsLookup(newclazz).filter(method.paramsCount == _.paramsCount).toList // newmeths
-    if (meths.isEmpty)
-      Some(DirectMissingMethodProblem(method))
+  protected def check(oldmeth: MethodInfo, newclazz: ClassInfo, methsLookup: ClassInfo => Iterator[MethodInfo]): Option[Problem] = {
+    val newmeths = methsLookup(newclazz).filter(oldmeth.paramsCount == _.paramsCount).toList
+    if (newmeths.isEmpty)
+      Some(DirectMissingMethodProblem(oldmeth))
     else {
-      meths.find(newMethod => hasMatchingDescriptorAndSignature(method, newMethod)) match {
-        case Some(found) => checkRules(rules)(method, found)
-        case None        =>
-          val filtered = meths.filter(method.matchesType(_))
-          filtered.find(_.tpe.resultType == method.tpe.resultType) match {
-            case Some(found) => Some(IncompatibleSignatureProblem(method, found))
-            case None        =>
-              val oldmethsDescriptors = methsLookup(method.owner).map(_.descriptor).toSet
-              if (meths.forall(newmeth => oldmethsDescriptors.contains(newmeth.descriptor)))
-                Some(DirectMissingMethodProblem(method))
+      newmeths.find(newmeth => hasMatchingDescriptorAndSignature(oldmeth, newmeth)) match {
+        case Some(newmeth) => checkRules(rules)(oldmeth, newmeth)
+        case None          =>
+          val newmethAndBridges = newmeths.filter(oldmeth.matchesType(_)) // _the_ corresponding new method + its bridges
+          newmethAndBridges.find(_.tpe.resultType == oldmeth.tpe.resultType) match {
+            case Some(newmeth) => Some(IncompatibleSignatureProblem(oldmeth, newmeth))
+            case None          =>
+              val oldmethsDescriptors = methsLookup(oldmeth.owner).map(_.descriptor).toSet
+              if (newmeths.forall(newmeth => oldmethsDescriptors.contains(newmeth.descriptor)))
+                Some(DirectMissingMethodProblem(oldmeth))
               else {
-                filtered match {
-                  case Nil        => Some(IncompatibleMethTypeProblem(method, uniques(meths)))
-                  case first :: _ => Some(IncompatibleResultTypeProblem(method, first))
+                newmethAndBridges match {
+                  case Nil          => Some(IncompatibleMethTypeProblem(oldmeth, uniques(newmeths)))
+                  case newmeth :: _ => Some(IncompatibleResultTypeProblem(oldmeth, newmeth))
                 }
               }
           }


### PR DESCRIPTION
In #362 I changed the logic so that when an overloaded is dropped it 
doesn't get reported as an "incompatible method type" or "incompatible 
result type" problem.

Looking back the logic is quite short-sighted.

So here I attempt to make it more straight-forward: if there were 
overloads, then the method is missing - it's not incompatible.

(Split into 2 commits.)