### PR TITLE
Fix integration tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ inThisBuild(Seq(
   scmInfo := Some(ScmInfo(url("https://github.com/lightbend/mima"), "scm:git:git@github.com:lightbend/mima.git")),
   dynverVTagPrefix := false,
   scalacOptions := Seq("-feature", "-deprecation", "-Xlint"),
+  useCoursier := false, // b/c otherwise IntegrationTest/test uses scala-library-2.12 always
 //resolvers += stagingResolver,
 ))
 

--- a/functional-tests/src/it/scala-library-2-13/test.conf
+++ b/functional-tests/src/it/scala-library-2-13/test.conf
@@ -16,4 +16,33 @@ filter.problems=[
   #   <T:Ljava/lang/Object;>(Lscala/concurrent/Awaitable<TT;>;Lscala/concurrent/duration/Duration;)TT;^Ljava/lang/Exception;
   { matchName="scala.concurrent.Await.result"     , problemName=IncompatibleSignatureProblem }
   { matchName="scala.concurrent.Awaitable.result" , problemName=IncompatibleSignatureProblem }
+
+  # scala/scala#8300
+  { matchName="scala.collection.ArrayOps$GroupedIterator"   , problemName=FinalClassProblem             }
+  { matchName="scala.collection.immutable.ArraySeq.stepper" , problemName=DirectAbstractMethodProblem   }
+  { matchName="scala.collection.immutable.ArraySeq.stepper" , problemName=ReversedAbstractMethodProblem }
+  { matchName="scala.collection.mutable.ArraySeq.stepper"   , problemName=DirectAbstractMethodProblem   }
+  { matchName="scala.collection.mutable.ArraySeq.stepper"   , problemName=ReversedAbstractMethodProblem }
+
+  # scala/scala#8367
+  { matchName="scala.collection.immutable.Stream.find" , problemName=FinalMethodProblem }
+
+  # scala/scala#8410
+  { matchName="scala.collection.immutable.Vector.gotoPosWritable1"                   , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.Vector.gotoPosWritable1$default$4"         , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.Vector.nullSlotAndCopy"                    , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.Vector.nullSlotAndCopy$default$3"          , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.VectorBuilder.gotoPosWritable1"            , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.VectorBuilder.gotoPosWritable1$default$4"  , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.VectorBuilder.nullSlotAndCopy"             , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.VectorBuilder.nullSlotAndCopy$default$3"   , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.VectorIterator.gotoPosWritable1"           , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.VectorIterator.gotoPosWritable1$default$4" , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.VectorIterator.nullSlotAndCopy"            , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.VectorIterator.nullSlotAndCopy$default$3"  , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.VectorPointer.gotoPosWritable1"            , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.VectorPointer.gotoPosWritable1$default$4"  , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.VectorPointer.nullSlotAndCopy"             , problemName=DirectMissingMethodProblem }
+  { matchName="scala.collection.immutable.VectorPointer.nullSlotAndCopy$default$3"   , problemName=DirectMissingMethodProblem }
+
 ]


### PR DESCRIPTION
Upgrading to sbt 1.3 (and, therefore, switching from Ivy to Coursier) broke how the integration tests work, as only 2.12 scala-library is used instead of 2.10-2.13 libraries (scala-reflect is fine):

* before 1.3 https://travis-ci.org/lightbend/mima/jobs/575703798#L285-L287
* after 1.3 https://travis-ci.org/lightbend/mima/jobs/581142473#L410-L413

As a result, setting `useCoursier := false` results in:

```
com.typesafe.tools.mima.lib.CollectProblemsTest$TestFailed: 'it-scala-library-2-13' failed.
The following 22 problems were reported but not expected:
  - class scala.collection.ArrayOps#GroupedIterator is declared final in new version
  - method nullSlotAndCopy(Array[Array[java.lang.Object]],Int,Array[java.lang.Object])Array[java.lang.Object] in class scala.collection.immutable.VectorBuilder does not have a correspondent in new version
  - synthetic method nullSlotAndCopy$default$3()scala.runtime.Null# in class scala.collection.immutable.VectorBuilder does not have a correspondent in new version
  - method gotoPosWritable1(Int,Int,Int,Array[java.lang.Object])Unit in class scala.collection.immutable.VectorBuilder does not have a correspondent in new version
  - synthetic method gotoPosWritable1$default$4()Array[java.lang.Object] in class scala.collection.immutable.VectorBuilder does not have a correspondent in new version
  - method nullSlotAndCopy(Array[Array[java.lang.Object]],Int,Array[java.lang.Object])Array[java.lang.Object] in class scala.collection.immutable.VectorIterator does not have a correspondent in new version
  - synthetic method nullSlotAndCopy$default$3()scala.runtime.Null# in class scala.collection.immutable.VectorIterator does not have a correspondent in new version
  - method gotoPosWritable1(Int,Int,Int,Array[java.lang.Object])Unit in class scala.collection.immutable.VectorIterator does not have a correspondent in new version
  - synthetic method gotoPosWritable1$default$4()Array[java.lang.Object] in class scala.collection.immutable.VectorIterator does not have a correspondent in new version
  - method nullSlotAndCopy(Array[Array[java.lang.Object]],Int,Array[java.lang.Object])Array[java.lang.Object] in class scala.collection.immutable.Vector does not have a correspondent in new version
  - synthetic method nullSlotAndCopy$default$3()scala.runtime.Null# in class scala.collection.immutable.Vector does not have a correspondent in new version
  - method gotoPosWritable1(Int,Int,Int,Array[java.lang.Object])Unit in class scala.collection.immutable.Vector does not have a correspondent in new version
  - synthetic method gotoPosWritable1$default$4()Array[java.lang.Object] in class scala.collection.immutable.Vector does not have a correspondent in new version
  - method find(scala.Function1)scala.Option in class scala.collection.immutable.Stream is declared final in new version
  - method nullSlotAndCopy(Array[Array[java.lang.Object]],Int,Array[java.lang.Object])Array[java.lang.Object] in interface scala.collection.immutable.VectorPointer does not have a correspondent in new version
  - synthetic method nullSlotAndCopy$default$3()scala.runtime.Null# in interface scala.collection.immutable.VectorPointer does not have a correspondent in new version
  - method gotoPosWritable1(Int,Int,Int,Array[java.lang.Object])Unit in interface scala.collection.immutable.VectorPointer does not have a correspondent in new version
  - synthetic method gotoPosWritable1$default$4()Array[java.lang.Object] in interface scala.collection.immutable.VectorPointer does not have a correspondent in new version
  - abstract method stepper(scala.collection.StepperShape)scala.collection.Stepper in class scala.collection.immutable.ArraySeq does not have a correspondent in new version
  - in new version there is abstract method stepper(scala.collection.StepperShape)scala.collection.Stepper in class scala.collection.immutable.ArraySeq, which does not have a correspondent
  - abstract method stepper(scala.collection.StepperShape)scala.collection.Stepper in class scala.collection.mutable.ArraySeq does not have a correspondent in new version
  - in new version there is abstract method stepper(scala.collection.StepperShape)scala.collection.Stepper in class scala.collection.mutable.ArraySeq, which does not have a correspondent
```

😭 