### PR TITLE
Simplify ClassInfo#concreteMethods

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassInfo.scala
@@ -118,8 +118,7 @@ sealed abstract class ClassInfo(val owner: PackageInfo) extends InfoLike with Eq
   /** The concrete methods of this trait. */
   final lazy val concreteMethods: List[MethodInfo] = {
     if (isTrait) methods.value.filter(m => hasStaticImpl(m) || m.isConcrete)
-    else if (isClass || isInterface) methods.value.filter(_.isConcrete)
-    else Nil
+    else methods.value.filter(_.isConcrete)
   }
 
   /** The subset of concrete methods of this trait that are abstract at the JVM level.


### PR DESCRIPTION
def isClass = !isTrait && !isInterface

Therefore

    isClass || isInterface
    (!isTrait && !isInterface) || isInterface     inline isClass
    isInterface || (!isTrait && !isInterface)     flip ||
    isInterface || !isTrait                       subsume !isInterface

But given the precending `if (isTrait)` it's really

    isTrait || isInterface || !isTrait

therefore it can be simplified to just isInterface.