### PR TITLE
Fix 'ResultTypeChanged' negative compilation test

### DIFF
--- a/functional-tests/src/test/class-method-result-type-changed-nok/app/App.scala
+++ b/functional-tests/src/test/class-method-result-type-changed-nok/app/App.scala
@@ -1,3 +1,5 @@
-object Main extends App {
-  println(new Foo().bar)
+object App {
+  def main(args: Array[String]): Unit = {
+    println(new Foo().bar)
+  }
 }


### PR DESCRIPTION
This test was supposed to test that running this code, compiled against v1,
against v2, would indeed fail.

Unfortunately it didn't have the expected class name, so it already failed
for that reason.