### PR TITLE
build: Sync the setup of App & Test more

### DIFF
--- a/project/TestsPlugin.scala
+++ b/project/TestsPlugin.scala
@@ -135,11 +135,14 @@ object TestsPlugin extends AutoPlugin {
     scalaVersion := testScalaVersion.value,
     inConfig(V1)(funTestPerConfigSettings),
     inConfig(V2)(funTestPerConfigSettings),
-    inConfig(App)(funTestPerConfigSettings),
+    inConfig(App)(Def.settings(
+      funTestPerConfigSettings,
+      run / trapExit := false,
+    )),
     inConfig(Test)(Def.settings(
       internalDependencyClasspath ++= (V2 / exportedProducts).value,
       internalDependencyClasspath ++= (App / exportedProducts).value,
-      run / mainClass := Some("App"),
+      run / mainClass := (App / run / mainClass).value,
       run / trapExit  := false,
     )),
     Global / onLoad += oracleFileCheck.value,


### PR DESCRIPTION
Make App & Test use the same mainClass.  Actually allow it to be called
anything (though "App" is now the tradition).

Also run in the same way, without trapping exit.