### PR TITLE
Add test object-loses-type-alias-ok

### DIFF
--- a/functional-tests/src/test/object-loses-type-alias-ok/app/App.scala
+++ b/functional-tests/src/test/object-loses-type-alias-ok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(A)
+  }
+}

--- a/functional-tests/src/test/object-loses-type-alias-ok/v1/A.scala
+++ b/functional-tests/src/test/object-loses-type-alias-ok/v1/A.scala
@@ -1,0 +1,3 @@
+object A {
+  type Str = java.lang.String
+}

--- a/functional-tests/src/test/object-loses-type-alias-ok/v2/A.scala
+++ b/functional-tests/src/test/object-loses-type-alias-ok/v2/A.scala
@@ -1,0 +1,1 @@
+object A


### PR DESCRIPTION
Type aliases can't be top-level (in the normal way, not in the Dotty
way) because that type definition must live in some bytecode somewhere.

So I wanted to check that that doesn't have any binary compatibility
concerns if you lose the alias.  (In truth I was double-checking
https://github.com/scala/bug/issues/11888#issuecomment-590302431).