### PR TITLE
Fix classpath handling in MiMaLib/SbtMima/CollectProblemsTest

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/package.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/package.scala
@@ -1,18 +1,6 @@
 package com.typesafe.tools.mima
 
-import java.io.File
-
-import scala.reflect.io.AbstractFile
-import scala.tools.nsc.classpath.AggregateClassPath
-import scala.tools.nsc.util.ClassPath
-
 package object core {
   /** Returns `true` for problems to keep, `false` for problems to drop. */
   type ProblemFilter = Problem => Boolean
-
-  private[mima] def pathToClassPath(f: File): Option[ClassPath] =
-    Option(AbstractFile.getDirectory(f)).map(DeprecatedPathApis.newClassPath(_, Config.settings))
-
-  private[mima] def aggregateClassPath(cp: Seq[File]): ClassPath =
-    AggregateClassPath.createAggregate(cp.flatMap(pathToClassPath(_)): _*)
 }

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
@@ -3,18 +3,15 @@ package com.typesafe.tools.mima.lib
 import java.io.File
 
 import com.typesafe.config.ConfigFactory
-import com.typesafe.tools.mima.core.{ Config, Problem, aggregateClassPath }
+import com.typesafe.tools.mima.core.Problem
 
 import scala.io.Source
-import scala.tools.nsc.classpath.AggregateClassPath
 
 object CollectProblemsTest {
 
   // Called via reflection from TestsPlugin
-  def runTest(testClasspath: Array[File], testName: String, oldJarOrDir: File, newJarOrDir: File, baseDir: File, oracleFile: File): Unit = {
-    val testClassPath = aggregateClassPath(testClasspath)
-    val classpath = AggregateClassPath.createAggregate(testClassPath, Config.baseClassPath)
-    val mima = new MiMaLib(classpath)
+  def runTest(cp: Array[File], testName: String, oldJarOrDir: File, newJarOrDir: File, baseDir: File, oracleFile: File): Unit = {
+    val mima = new MiMaLib(cp)
 
     val configFile = new File(baseDir, "test.conf")
     val configFallback = ConfigFactory.parseString("filter { problems = [] }")

--- a/functional-tests/src/test/class-method-del-override-from-Throwable-ok/app/App.scala
+++ b/functional-tests/src/test/class-method-del-override-from-Throwable-ok/app/App.scala
@@ -1,0 +1,5 @@
+object App {
+  def main(args: Array[String]): Unit = {
+    println(new A().fillInStackTrace)
+  }
+}

--- a/functional-tests/src/test/class-method-del-override-from-Throwable-ok/problems.txt
+++ b/functional-tests/src/test/class-method-del-override-from-Throwable-ok/problems.txt
@@ -1,0 +1,8 @@
+# was:  (https://github.com/lightbend/mima/issues/477)
+#   com.typesafe.tools.mima.lib.CollectProblemsTest$TestFailed: 'test-class-method-del-override-from-Throwable-ok' failed.
+#   The following 1 problems were reported but not expected:
+#     - method fillInStackTrace()java.lang.Throwable in class A does not have a correspondent in new version
+#   Filter with:
+#     ProblemFilters.exclude[DirectMissingMethodProblem]("A.fillInStackTrace"),
+#   Or filter with:
+#     { matchName="A.fillInStackTrace" , problemName=DirectMissingMethodProblem }

--- a/functional-tests/src/test/class-method-del-override-from-Throwable-ok/v1/A.scala
+++ b/functional-tests/src/test/class-method-del-override-from-Throwable-ok/v1/A.scala
@@ -1,0 +1,3 @@
+class A extends Throwable {
+  final override def fillInStackTrace(): Throwable = this
+}

--- a/functional-tests/src/test/class-method-del-override-from-Throwable-ok/v2/A.scala
+++ b/functional-tests/src/test/class-method-del-override-from-Throwable-ok/v2/A.scala
@@ -1,0 +1,1 @@
+class A extends Throwable

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -23,8 +23,8 @@ object MimaSettings {
       // * com.typesafe.tools.mima.plugin.MimaKeys
       // * com.typesafe.tools.mima.core.ProblemFilters
       // * com.typesafe.tools.mima.core.*Problem
-      // to a less degree (some re-implementors):
-      // * com.typesafe.tools.mima.lib.MiMaLib.collectProblems
+      exclude[Problem]("*mima.core.package.*"),
+      exclude[Problem]("*mima.lib.MiMaLib.this"),
     ),
   )
 }

--- a/project/TestsPlugin.scala
+++ b/project/TestsPlugin.scala
@@ -151,7 +151,7 @@ object TestsPlugin extends AutoPlugin {
     val testClass = loader.loadClass("com.typesafe.tools.mima.lib.CollectProblemsTest$")
     val testRunner = testClass.getField("MODULE$").get(null).asInstanceOf[{
       def runTest(
-          testClasspath: Array[File],
+          cp: Array[File],
           testName: String,
           oldJarOrDir: File,
           newJarOrDir: File,
@@ -161,11 +161,11 @@ object TestsPlugin extends AutoPlugin {
     }]
 
     // Add the scala-library to the MiMa classpath used to run this test
-    val testClasspath = Attributed.data(cp).filter(_.getName.endsWith("scala-library.jar")).toArray
+    val jars = Attributed.data(cp).filter(_.getName.endsWith("scala-library.jar")).toArray
 
     try {
       import scala.language.reflectiveCalls
-      testRunner.runTest(testClasspath, name.value, oldJarOrDir, newJarOrDir, baseDirectory.value, oracleFile.value)
+      testRunner.runTest(jars, name.value, oldJarOrDir, newJarOrDir, baseDirectory.value, oracleFile.value)
       streams.value.log.info(s"Test '${name.value}' succeeded.")
     } catch {
       case e: Exception =>

--- a/project/TestsPlugin.scala
+++ b/project/TestsPlugin.scala
@@ -107,7 +107,7 @@ object TestsPlugin extends AutoPlugin {
     }
     (App / fgRun).toTask("").value
     val result = (Test / fgRun).toTask("").result.value
-    if (IO.read(oracleFile.value).isEmpty) {
+    if (IO.readLines(oracleFile.value).forall(_.startsWith("#"))) {
       if (!pending) Result.tryValue(result)
     } else {
       if (!pending) result.toEither.foreach { (_: Unit) =>

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
@@ -22,7 +22,7 @@ object SbtMima {
   /** Runs MiMa and returns a two lists of potential binary incompatibilities,
       the first for backward compatibility checking, and the second for forward checking. */
   def runMima(prev: File, curr: File, cp: Classpath, dir: String, log: Logging): (List[Problem], List[Problem]) = {
-    val mimaLib = new MiMaLib(aggregateClassPath(Attributed.data(cp)), log)
+    val mimaLib = new MiMaLib(Attributed.data(cp), log)
     def checkBC = mimaLib.collectProblems(prev, curr)
     def checkFC = mimaLib.collectProblems(curr, prev)
     dir match {


### PR DESCRIPTION
Previously CollectProblemsTest (which runs is used to run the test
suite) appended Config.baseClassPath at the end of the test classpath,
while SbtMima didn't.  This lead to a false positive around types like
Throwable.

After verifying that the problem presents itself by removing the
baseClassPath, I fixed the bug by pushing this setup into the shared
MiMaLib, thus removing it as a difference between SbtMima and
CollectProblemsTest.

Fixes #477