### PR TITLE
Replace sys.exit(-1) with sys.error(msg)

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/Config.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/Config.scala
@@ -9,8 +9,5 @@ object Config {
 
   val baseClassPath = DeprecatedPathApis.newPathResolver(Config.settings).result
 
-  def fatal(msg: String): Nothing = {
-    Console.err.println(msg)
-    sys.exit(-1)
-  }
+  def fatal(msg: String): Nothing = sys.error(msg)
 }


### PR DESCRIPTION
## Problem
`sbt mimaReportBinaryIssues` is terminating the sbt process with `System.exit(-1)`.

```
sbt:lib-weepickle-spices-parsers-play25-v1> mimaReportBinaryIssues
not a directory or jar file: /Users/doug.roper/code/lib-weepickle-spices/parsers-play25/target/scala-2.11/classes
$
```

Similar error condition to #55, but this PR is about preventing shutdown of the sbt's JVM when a mima problem occurs.

We've [forked mima](https://github.com/rallyhealth/sbt-git-versioning/blob/43301a1108112818f56e7de2abeb034394e94f4f/src/main/scala/com/rallyhealth/sbt/semver/CustomMiMaLibMiMaExecutor.scala#L14-L37) over this issue, but I'd like to get us back on mainline.

## Testing
I've verified this manually using a snapshot:
```
sbt:lib-weepickle-spices> parsers-play25/mimaReportBinaryIssues
[error] stack trace is suppressed; run last parsers-play25 / mimaReportBinaryIssues for the full output
[error] (parsers-play25 / mimaReportBinaryIssues) not a directory or jar file: /Users/doug.roper/code/lib-weepickle-spices/parsers-play25/target/scala-2.11/classes
[error] Total time: 1 s, completed Apr 20, 2020 9:12:06 PM
```

I didn't add any new scripted tests since the change is pretty straightforward. Existing scripted tests all pass.

cc: @jrudolph @arkban