### PR TITLE
Add OpenJDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: scala
-jdk: openjdk8
 scala: 2.12.10
+jdk:
+- openjdk8
+- openjdk11
 
 jobs:
   include:


### PR DESCRIPTION
MiMa uses nsc's ClassPath, which has code JDK 9+'s JRT classpath.
So I'm thinking it would be good to test on both Java 8 and 11.