### PR TITLE
Misc: move Scala version check, fix log & formatting

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/lib/MiMaLib.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/lib/MiMaLib.scala
@@ -6,14 +6,7 @@ import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.core.util.log.{ ConsoleLogging, Logging }
 import com.typesafe.tools.mima.lib.analyze.Analyzer
 
-final class MiMaLib(cp: Seq[File], scalaVersion: String, log: Logging = ConsoleLogging) {
-  locally {
-    scalaVersion.take(5) match {
-      case "2.11." | "2.12." | "2.13." => () // ok
-      case _ => throw new IllegalArgumentException(s"MiMa supports Scala 2.10-2.13, not $scalaVersion")
-    }
-  }
-
+final class MiMaLib(cp: Seq[File], log: Logging = ConsoleLogging) {
   private val classpath = ClassPath.of(cp.flatMap(ClassPath.fromJarOrDir(_)) :+ ClassPath.base)
 
   private def createPackage(dirOrJar: File): PackageInfo = {

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/CollectProblemsTest.scala
@@ -11,7 +11,7 @@ object CollectProblemsTest {
 
   // Called via reflection from TestsPlugin
   def runTest(cp: Array[File], testName: String, oldJarOrDir: File, newJarOrDir: File, baseDir: File, oracleFile: File): Unit = {
-    val mima = new MiMaLib(cp, scala.util.Properties.versionNumberString)
+    val mima = new MiMaLib(cp)
 
     val configFile = new File(baseDir, "test.conf")
     val configFallback = ConfigFactory.parseString("filter { problems = [] }")

--- a/project/TestsPlugin.scala
+++ b/project/TestsPlugin.scala
@@ -126,20 +126,18 @@ object TestsPlugin extends AutoPlugin {
     scalaVersion := testScalaVersion.value,
     inConfig(V1)(funTestPerConfigSettings),
     inConfig(V2)(funTestPerConfigSettings),
-    inConfig(App)(Def.settings(
-      funTestPerConfigSettings,
-      run / trapExit := false,
-    )),
+    inConfig(App)(funTestPerConfigSettings),
+    inConfig(App)(run / trapExit := false),
     inConfig(Test)(Def.settings(
       internalDependencyClasspath ++= (V2 / exportedProducts).value,
       internalDependencyClasspath ++= (App / exportedProducts).value,
       run / mainClass := (App / run / mainClass).value,
-      run / trapExit  := false,
+      run / trapExit  := (App / run / trapExit).value,
     )),
-    Global / onLoad += oracleFileCheck.value,
+    Global / onLoad     += oracleFileCheck.value,
     testCollectProblems := testCollectProblemsImpl.value,
-    testAppRun := testAppRunImpl.value,
-    Test / test := runFunctionalTest.value,
+    testAppRun          := testAppRunImpl.value,
+    Test / test         := runFunctionalTest.value,
   )
 
   private def runCollectProblemsTest(oldJarOrDir: File, newJarOrDir: File) = Def.task {

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
@@ -62,17 +62,22 @@ object SbtMima {
     val forwErrors = forward.filter(isReported(forwardFilters))
 
     val count = backErrors.size + forwErrors.size
-    val filteredCount = backward.size + forward.size - count
-    val filteredNote = if (filteredCount > 0) s" (filtered $filteredCount)" else ""
-    val msg = s"Failed binary compatibility check against $module! Found $count potential problems$filteredNote"
     val doLog = if (count == 0) log.verbose(_) else if (failOnProblem) log.error(_) else log.warn(_)
+    def logResult(msg: String) = doLog(s"$projectName: $msg")
 
-    doLog(s"$projectName: $msg")
-    for (p <- backErrors) doLog(pretty("current")(p))
-    for (p <- forwErrors) doLog(pretty("other")(p))
+    if (count == 0) {
+      logResult(s"Binary compatibility check against $module passed.")
+    } else {
+      val filteredCount = backward.size + forward.size - count
+      val filteredNote = if (filteredCount > 0) s" (filtered $filteredCount)" else ""
+      val msg = s"Failed binary compatibility check against $module! Found $count potential problems$filteredNote"
 
-    if (failOnProblem && count > 0) {
-      sys.error(msg)
+      logResult(msg)
+      for (p <- backErrors) doLog(pretty("current")(p))
+      for (p <- forwErrors) doLog(pretty("other")(p))
+
+      if (failOnProblem)
+        sys.error(msg)
     }
   }
 

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
@@ -22,7 +22,8 @@ object SbtMima {
   /** Runs MiMa and returns a two lists of potential binary incompatibilities,
       the first for backward compatibility checking, and the second for forward checking. */
   def runMima(prev: File, curr: File, cp: Classpath, dir: String, scalaVersion: String, log: Logging): (List[Problem], List[Problem]) = {
-    val mimaLib = new MiMaLib(Attributed.data(cp), scalaVersion, log)
+    sanityCheckScalaVersion(scalaVersion)
+    val mimaLib = new MiMaLib(Attributed.data(cp), log)
     def checkBC = mimaLib.collectProblems(prev, curr)
     def checkFC = mimaLib.collectProblems(curr, prev)
     dir match {
@@ -30,6 +31,13 @@ object SbtMima {
        case "forward" | "forwards"   => (Nil, checkFC)
        case "both"                   => (checkBC, checkFC)
        case _                        => (Nil, Nil)
+    }
+  }
+
+  private def sanityCheckScalaVersion(scalaVersion: String) = {
+    scalaVersion.take(5) match {
+      case "2.11." | "2.12." | "2.13." => () // ok
+      case _ => throw new IllegalArgumentException(s"MiMa supports Scala 2.10-2.13, not $scalaVersion")
     }
   }
 


### PR DESCRIPTION
In TestsPlugin I was trying to drop the:

    val cp = (functionalTests / Compile / fullClasspath).value // the test classpath from the functionalTest project for the test
    val si = (functionalTests / scalaInstance).value // get a reference to the already loaded Scala classes so we get the advantage of a warm jvm

for just making the functional projects use their own scalaInstance and just regular project dependsOn functionalTests.  But it turns out that that makes the tests take 80s seconds instead of 30s (even with classloader caching improvements in recent versions of sbt).  Oh well.