### PR TITLE
Allow calling SbtMima.runMima from other plugins

### DIFF
--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/MimaPlugin.scala
@@ -24,7 +24,6 @@ object MimaPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     mimaReportBinaryIssues := {
-      val log = new SbtLogger(streams.value)
       binaryIssuesIterator.value.foreach { case (moduleId, problems) =>
         SbtMima.reportModuleErrors(
           moduleId,
@@ -34,7 +33,7 @@ object MimaPlugin extends AutoPlugin {
           binaryIssueFilters.value,
           mimaBackwardIssueFilters.value,
           mimaForwardIssueFilters.value,
-          log,
+          streams.value.log,
           name.value,
         )
       }
@@ -78,7 +77,6 @@ object MimaPlugin extends AutoPlugin {
     val currentClassfiles = mimaCurrentClassfiles.value
     val cp = (fullClasspath in mimaFindBinaryIssues).value
     val sv = scalaVersion.value
-    val log = new SbtLogger(s)
 
     if (previousClassfiles eq NoPreviousClassfiles) {
       val msg = "mimaPreviousArtifacts not set, not analyzing binary compatibility"
@@ -88,7 +86,7 @@ object MimaPlugin extends AutoPlugin {
     }
 
     previousClassfiles.iterator.map { case (moduleId, prevClassfiles) =>
-      moduleId -> SbtMima.runMima(prevClassfiles, currentClassfiles, cp, mimaCheckDirection.value, sv, log)
+      moduleId -> SbtMima.runMima(prevClassfiles, currentClassfiles, cp, mimaCheckDirection.value, sv, s.log)
     }
   }
 

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtLogger.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtLogger.scala
@@ -2,12 +2,12 @@ package com.typesafe.tools.mima
 package plugin
 
 import com.typesafe.tools.mima.core.util.log.Logging
-import sbt.Keys._
+import sbt.Logger
 
 /** Wrapper on sbt logging for MiMa. */
-private[plugin] final class SbtLogger(s: TaskStreams) extends Logging {
-  def verbose(msg: String): Unit = s.log.verbose(msg)
-  def debug(msg: String): Unit   = s.log.debug(msg)
-  def warn(msg: String): Unit    = s.log.warn(msg)
-  def error(msg: String): Unit   = s.log.error(msg)
+private[plugin] final class SbtLogger(log: Logger) extends Logging {
+  def verbose(msg: String): Unit = log.verbose(msg)
+  def debug(msg: String): Unit   = log.debug(msg)
+  def warn(msg: String): Unit    = log.warn(msg)
+  def error(msg: String): Unit   = log.error(msg)
 }

--- a/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
+++ b/sbtplugin/src/main/scala/com/typesafe/tools/mima/plugin/SbtMima.scala
@@ -4,7 +4,6 @@ package plugin
 import java.io.File
 
 import com.typesafe.tools.mima.core._
-import com.typesafe.tools.mima.core.util.log.Logging
 import com.typesafe.tools.mima.lib.MiMaLib
 import sbt._
 import sbt.Keys.{ Classpath, TaskStreams }
@@ -21,7 +20,8 @@ import scala.util.matching._
 object SbtMima {
   /** Runs MiMa and returns a two lists of potential binary incompatibilities,
       the first for backward compatibility checking, and the second for forward checking. */
-  def runMima(prev: File, curr: File, cp: Classpath, dir: String, scalaVersion: String, log: Logging): (List[Problem], List[Problem]) = {
+  def runMima(prev: File, curr: File, cp: Classpath, dir: String, scalaVersion: String, logger: Logger): (List[Problem], List[Problem]) = {
+    val log = new SbtLogger(logger)
     sanityCheckScalaVersion(scalaVersion)
     val mimaLib = new MiMaLib(Attributed.data(cp), log)
     def checkBC = mimaLib.collectProblems(prev, curr)
@@ -50,11 +50,12 @@ object SbtMima {
       filters: Seq[ProblemFilter],
       backwardFilters: Map[String, Seq[ProblemFilter]],
       forwardFilters: Map[String, Seq[ProblemFilter]],
-      log: Logging,
+      logger: Logger,
       projectName: String,
   ): Unit = {
     // filters * found is n-squared, it's fixable in principle by special-casing known
     // filter types or something, not worth it most likely...
+    val log = new SbtLogger(logger)
 
     def isReported(versionedFilters: Map[String, Seq[ProblemFilter]])(problem: Problem) = {
       ProblemReporting.isReported(module.revision, filters, versionedFilters)(problem)


### PR DESCRIPTION
This used to be possible (i.e.
https://github.com/akka/akka-http/blob/master/project/ValidatePullRequest.scala#L562)
by creating an instance of SbtLogger, which was
(correctly) made private[plugin] in 67fb8d46c53ffc43756e9aea00bea6db5b05ecc2.

This cleans up the SbtMima API so no now-internal API's are needed to call it.