### PR TITLE
Drop a redundant Travis CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: scala
 scala: 2.12.11
+script: "sbt test mimaReportBinaryIssues 'set sbtplugin/scriptedSbt := \"1.2.8\"' 'scripted sbt-mima-plugin/minimal' IntegrationTest/test"
 jdk:
 - openjdk8
 - openjdk11
 
 jobs:
   include:
-  - { script: "sbt mimaReportBinaryIssues test IntegrationTest/test
-        'set sbtplugin/scriptedSbt := \"1.2.8\"' 'scripted sbt-mima-plugin/minimal'" }
   - { name: testFunctional 2.11, script: sbt -Dmima.testScalaVersion=2.11.12 testFunctional }
   - { name: testFunctional 2.12, script: sbt -Dmima.testScalaVersion=2.12.11 testFunctional }
   - { name: testFunctional 2.13, script: sbt -Dmima.testScalaVersion=2.13.2  testFunctional }


### PR DESCRIPTION
Previously the setup created two "sbt ++$TRAVIS_SCALA test" build jobs,
for openjdk8 and openjdk11, and then the rest of the jobs in the "jobs"
section (once, on openjdk8 - because it's the first jdk value).

Now it will run the whole test/mimaReportBinaryIssues/etc job once on
Java 8 and once on Java 11, and then testFunctional/etc on Java 8 (like
before).