### PR TITLE
Switch the build to useCoursier!

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ inThisBuild(Seq(
   scmInfo := Some(ScmInfo(url("https://github.com/lightbend/mima"), "scm:git:git@github.com:lightbend/mima.git")),
   dynverVTagPrefix := false,
   scalacOptions := Seq("-feature", "-deprecation", "-Xlint"),
-  useCoursier := false, // b/c otherwise IntegrationTest/test uses scala-library-2.12 always
   resolvers ++= (if (isStaging) List(stagingResolver) else Nil),
   publishTo := Some(if (isSnapshot.value) Opts.resolver.sonatypeSnapshots else Opts.resolver.sonatypeStaging),
 ))


### PR DESCRIPTION
The original issue is gone now that the jars are resolved
programmatically (also using Coursier, in `IntegrationTests`).