### PR TITLE
Remove .sbtopts

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,2 +1,0 @@
--J-XX:ReservedCodeCacheSize=256M
--J-Xmx3072M


### PR DESCRIPTION
I'm experimenting with a snapshot build of MiMa, using `export
SBT_OPTS=-Dsbt.version=1.4.0-SNAPSHOT` to select it (so I don't
accidentally commit the build.properties change).  Can Zinc build on
Travis CI without it, in 2020?