### PR TITLE
Close classpath directory after listing

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassPath.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassPath.scala
@@ -47,7 +47,12 @@ private[mima] object ClassPath {
   private def javaBootCp               = expandCp(System.getProperty("sun.boot.class.path", ""))
 
   import scala.collection.JavaConverters._
-  private def list(p: Path)      = Files.newDirectoryStream(p).asScala.toStream.sortBy(_.toString)
+  private def list(p: Path)      = {
+    val stream = Files.newDirectoryStream(p)
+    val list = stream.asScala.toStream.sortBy(_.toString)
+    stream.close()
+    list
+  }
   private def listDir(p: Path)   = if (Files.isDirectory(p)) list(p) else Stream.empty
   private def readLink(p: Path)  = if (Files.isSymbolicLink(p)) Files.readSymbolicLink(p) else p
   private def rootPath(p: Path)  = FileSystems.newFileSystem(p, null).getPath("/")


### PR DESCRIPTION
A `newDirectoryStream` must be closed after reading. We can do that
immediately because we're sorting the list so we have to consume
the entire stream anyway.