### PR TITLE
Enabled cross build with Scala 2.13 for core and functional-tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,8 @@ commands += Command.command("testStaging") { state =>
   prep ::: "mimaReportBinaryIssues" :: state
 }
 
+val supportedScalaVersions = Seq("2.12.13", "2.13.5")
+
 val root = project.in(file(".")).settings(
   name := "mima",
   crossScalaVersions := Nil,
@@ -33,10 +35,13 @@ val root = project.in(file(".")).settings(
 )
 aggregateProjects(core, sbtplugin, functionalTests)
 
-val munit = "org.scalameta" %% "munit" % "0.7.23"
+val munit = "org.scalameta" %% "munit" % "0.7.25"
+val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.3"
 
 val core = project.settings(
   name := "mima-core",
+  crossScalaVersions := supportedScalaVersions,
+  libraryDependencies += scalaCollectionCompat,
   libraryDependencies += munit % Test,
   testFrameworks += new TestFramework("munit.Framework"),
   MimaSettings.mimaSettings,
@@ -56,7 +61,7 @@ val core = project.settings(
 val sbtplugin = project.enablePlugins(SbtPlugin).dependsOn(core).settings(
   name := "sbt-mima-plugin",
   // drop the previous value to drop running Test/compile
-  scriptedDependencies := Def.task(()).dependsOn(publishLocal, publishLocal in core).value,
+  scriptedDependencies := Def.task(()).dependsOn(publishLocal, core / publishLocal).value,
   scriptedLaunchOpts += s"-Dplugin.version=${version.value}",
   scriptedLaunchOpts += s"-Dsbt.boot.directory=${file(sys.props("user.home")) / ".sbt" / "boot"}",
   MimaSettings.mimaSettings,
@@ -67,6 +72,7 @@ val functionalTests = Project("functional-tests", file("functional-tests"))
   .dependsOn(core)
   .configs(IntegrationTest)
   .settings(
+    crossScalaVersions := supportedScalaVersions,
     libraryDependencies += "com.typesafe" % "config" % "1.4.1",
     libraryDependencies += "io.get-coursier" %% "coursier" % "2.0.16",
     libraryDependencies += munit,


### PR DESCRIPTION
The sbt plugin stays on Scala 2.12 as sbt 1.x does.

I needed to adapt one source file to the new collection API and introduced new dependency `scala-collection-compat` which provides said new API to the older collections.

Fix https://github.com/lightbend/mima/issues/617