### PR TITLE
remove dependency on scala-collection-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,12 +36,10 @@ val root = project.in(file(".")).settings(
 aggregateProjects(core, sbtplugin, functionalTests)
 
 val munit = "org.scalameta" %% "munit" % "0.7.25"
-val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.3"
 
 val core = project.settings(
   name := "mima-core",
   crossScalaVersions += scala213,
-  libraryDependencies += scalaCollectionCompat,
   libraryDependencies += munit % Test,
   testFrameworks += new TestFramework("munit.Framework"),
   MimaSettings.mimaSettings,

--- a/core/src/main/scala/com/typesafe/tools/mima/core/PackageInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/PackageInfo.scala
@@ -2,7 +2,6 @@ package com.typesafe.tools.mima.core
 
 import scala.annotation.tailrec
 import scala.collection.mutable
-import scala.collection.compat._
 
 sealed class SyntheticPackageInfo(val owner: PackageInfo, val name: String) extends PackageInfo {
   def definitions   = owner.definitions
@@ -25,11 +24,12 @@ sealed class ConcretePackageInfo(val owner: PackageInfo, cp: ClassPath, pkg: Str
   def definitions = defs
 
   lazy val packages: mutable.Map[String, PackageInfo] =
-    mutable.Map.from(
+    // this way of building the map cross-compiles on 2.12 and 2.13 without
+    // needing to bring in scala-collection-compat
+    mutable.Map() ++
       cp.packages(pkg).map { p =>
         p.stripPrefix(s"$pkg.") -> new ConcretePackageInfo(this, cp, p, defs)
       }
-    )
 
   lazy val classes =
     cp.classes(pkg).map { f =>


### PR DESCRIPTION
this is easier than arguing with dbuild about conflicting cross-version suffixes over at https://github.com/scala/community-build/pull/1407