### PR TITLE
Ignore pickle/bytecode method mismatch

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileParser.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ClassfileParser.scala
@@ -133,8 +133,8 @@ final class ClassfileParser private (in: BufferReader, pool: ConstantPool) {
 
     val numAnnots = in.nextChar
     var i = 0
-    var bytes: Array[Byte] = null
-    while (i < numAnnots && bytes == null) {
+    var bytes = new Array[Byte](0)
+    while (i < numAnnots && bytes.length == 0) {
       pool.getExternalName(in.nextChar) match {
         case ScalaSignatureAnnot     => checkScalaSigAnnotArg(); bytes = parseScalaSigBytes()
         case ScalaLongSignatureAnnot => checkScalaSigAnnotArg(); bytes = parseScalaLongSigBytes()
@@ -142,10 +142,7 @@ final class ClassfileParser private (in: BufferReader, pool: ConstantPool) {
       }
       i += 1
     }
-    if (bytes != null) {
-      val pb = new PickleBuffer(bytes)
-      MimaUnpickler.unpickleClass(pb, clazz, in.path)
-    }
+    MimaUnpickler.unpickleClass(new PickleBuffer(bytes), clazz, in.path)
   }
 
   private final val ScalaSignatureAnnot     = "Lscala.reflect.ScalaSignature;"

--- a/core/src/main/scala/com/typesafe/tools/mima/core/PickleFormat.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/PickleFormat.scala
@@ -6,104 +6,6 @@ object PickleFormat {
    * Symbol table attribute format:
    *   Symtab         = nentries_Nat {Entry}
    *
-   *   Entry          = 1 TERMNAME len_Nat NameInfo
-   *                  | 2 TYPENAME len_Nat NameInfo
-   *                  |
-   *                  | 3   NONEsym len_Nat
-   *                  | 4   TYPEsym len_Nat SymbolInfo
-   *                  | 5  ALIASsym len_Nat SymbolInfo
-   *                  | 6  CLASSsym len_Nat SymbolInfo [thistype_Ref]
-   *                  | 7 MODULEsym len_Nat SymbolInfo
-   *                  | 8    VALsym len_Nat [defaultGetter_Ref] SymbolInfo [alias_Ref]  // defaultGetter_Ref no longer needed
-   *                  |
-   *                  | 9          EXTref len_Nat name_Ref [owner_Ref]
-   *                  | 10 EXTMODCLASSref len_Nat name_Ref [owner_Ref]
-   *                  |
-   *                  | 11             NOtpe len_Nat
-   *                  | 12       NOPREFIXtpe len_Nat
-   *                  | 13           THIStpe len_Nat      sym_Ref
-   *                  | 14         SINGLEtpe len_Nat     type_Ref  sym_Ref
-   *                  | 15       CONSTANTtpe len_Nat constant_Ref
-   *                  | 16        TYPEREFtpe len_Nat     type_Ref  sym_Ref {targ_Ref}
-   *                  | 17     TYPEBOUNDStpe len_Nat      tpe_Ref  tpe_Ref
-   *                  | 18        REFINEDtpe len_Nat classsym_Ref {tpe_Ref}
-   *                  | 19      CLASSINFOtpe len_Nat classsym_Ref {tpe_Ref}
-   *                  | 20         METHODtpe len_Nat      tpe_Ref {sym_Ref}
-   *                  | 21          POLYTtpe len_Nat      tpe_Ref {sym_Ref}
-   *                  | 22 IMPLICITMETHODtpe len_Nat      tpe_Ref {sym_Ref}   // deprecated
-   *                  | 52          SUPERtpe len_Nat      tpe_Ref  tpe_Ref
-   *                  |
-   *                  | 24 LITERALunit    len_Nat
-   *                  | 25 LITERALboolean len_Nat value_Long
-   *                  | 26 LITERALbyte    len_Nat value_Long
-   *                  | 27 LITERALshort   len_Nat value_Long
-   *                  | 28 LITERALchar    len_Nat value_Long
-   *                  | 29 LITERALint     len_Nat value_Long
-   *                  | 30 LITERALlong    len_Nat value_Long
-   *                  | 31 LITERALfloat   len_Nat value_Long
-   *                  | 32 LITERALdouble  len_Nat value_Long
-   *                  | 33 LITERALstring  len_Nat  name_Ref
-   *                  | 34 LITERALnull    len_Nat
-   *                  | 35 LITERALclass   len_Nat   tpe_Ref
-   *                  | 36 LITERALenum    len_Nat   sym_Ref
-   *                  | 37 LITERALsymbol  len_Nat  name_Ref
-   *                  |
-   *                  | 40 SYMANNOT         len_Nat            sym_Ref  AnnotInfoBody
-   *                  | 41 CHILDREN         len_Nat            sym_Ref     {sym_Ref}
-   *                  | 42     ANNOTATEDtpe len_Nat           [sym_Ref]     tpe_Ref {annotinfo_Ref} // sym_Ref no longer needed
-   *                  | 43 ANNOTINFO        len_Nat      AnnotInfoBody
-   *                  | 44 ANNOTARGARRAY    len_Nat {constAnnotArg_Ref}
-   *                  | 47 DEBRUIJNINDEXtpe len_Nat          level_Nat    index_Nat   // deprecated
-   *                  | 48   EXISTENTIALtpe len_Nat           type_Ref  {symbol_Ref}
-   *                  |
-   *                  | 49 TREE len_Nat
-   *                  |    1           EMPTYtree
-   *                  |    2         PACKAGEtree type_Ref      sym_Ref        mods_Ref  name_Ref      {tree_Ref}
-   *                  |    3           CLASStree type_Ref      sym_Ref        mods_Ref  name_Ref       tree_Ref {tree_Ref}
-   *                  |    4          MODULEtree type_Ref      sym_Ref        mods_Ref  name_Ref       tree_Ref
-   *                  |    5          VALDEFtree type_Ref      sym_Ref        mods_Ref  name_Ref       tree_Ref  tree_Ref
-   *                  |    6          DEFDEFtree type_Ref      sym_Ref        mods_Ref  name_Ref numtparams_Nat {tree_Ref} numparamss_Nat {numparams_Nat {tree_Ref}} tree_Ref tree_Ref
-   *                  |    7         TYPEDEFtree type_Ref      sym_Ref        mods_Ref  name_Ref       tree_Ref {tree_Ref}
-   *                  |    8           LABELtree type_Ref      sym_Ref        tree_Ref {tree_Ref}
-   *                  |    9          IMPORTtree type_Ref      sym_Ref        tree_Ref {name_Ref       name_Ref}
-   *                  |   11          DOCDEFtree type_Ref      sym_Ref      string_Ref  tree_Ref
-   *                  |   12        TEMPLATEtree type_Ref      sym_Ref  numparents_Nat {tree_Ref}      tree_Ref {tree_Ref}
-   *                  |   13           BLOCKtree type_Ref     tree_Ref       {tree_Ref}
-   *                  |   14            CASEtree type_Ref     tree_Ref        tree_Ref  tree_Ref
-   *                  |   15        SEQUENCEtree type_Ref    {tree_Ref}
-   *                  |   16     ALTERNATIVEtree type_Ref    {tree_Ref}
-   *                  |   17            STARtree type_Ref    {tree_Ref}
-   *                  |   18            BINDtree type_Ref      sym_Ref  name_Ref  tree_Ref
-   *                  |   19         UNAPPLYtree type_Ref     tree_Ref {tree_Ref}
-   *                  |   20      ARRAYVALUEtree type_Ref     tree_Ref {tree_Ref}
-   *                  |   21        FUNCTIONtree type_Ref      sym_Ref  tree_Ref {tree_Ref}
-   *                  |   22          ASSIGNtree type_Ref     tree_Ref  tree_Ref
-   *                  |   23              IFtree type_Ref     tree_Ref  tree_Ref  tree_Ref
-   *                  |   24           MATCHtree type_Ref     tree_Ref {tree_Ref}
-   *                  |   25          RETURNtree type_Ref      sym_Ref  tree_Ref
-   *                  |   26             TREtree type_Ref     tree_Ref  tree_Ref {tree_Ref}
-   *                  |   27           THROWtree type_Ref     tree_Ref
-   *                  |   28             NEWtree type_Ref     tree_Ref
-   *                  |   29           TYPEDtree type_Ref     tree_Ref  tree_Ref
-   *                  |   30       TYPEAPPLYtree type_Ref     tree_Ref {tree_Ref}
-   *                  |   31           APPLYtree type_Ref     tree_Ref {tree_Ref}
-   *                  |   32    APPLYDYNAMICtree type_Ref      sym_Ref  tree_Ref {tree_Ref}
-   *                  |   33           SUPERtree type_Ref      sym_Ref  tree_Ref  name_Ref
-   *                  |   34            THIStree type_Ref      sym_Ref  name_Ref
-   *                  |   35          SELECTtree type_Ref      sym_Ref  tree_Ref  name_Ref
-   *                  |   36           IDENTtree type_Ref      sym_Ref  name_Ref
-   *                  |   37         LITERALtree type_Ref constant_Ref
-   *                  |   38            TYPEtree type_Ref
-   *                  |   39       ANNOTATEDtree type_Ref     tree_Ref  tree_Ref
-   *                  |   40   SINGLETONTYPEtree type_Ref     tree_Ref
-   *                  |   41  SELECTFROMTYPEtree type_Ref     tree_Ref  name_Ref
-   *                  |   42    COMPOUNDTYPEtree type_Ref     tree_Ref
-   *                  |   43     APPLIEDTYPEtree type_Ref     tree_Ref {tree_Ref}
-   *                  |   44      TYPEBOUNDStree type_Ref     tree_Ref  tree_Ref
-   *                  |   45 EXISTENTIALTYPEtree type_Ref     tree_Ref {tree_Ref}
-   *                  |
-   *                  | 50 MODIFIERS len_Nat flags_Long privateWithin_Ref
-   *
    *         NameInfo     = <character sequence of length len_Nat in UTF-8 format>
    *       SymbolInfo     = name_Ref owner_Ref flags_LongNat [privateWithin_Ref] info_Ref
    *             Long     = <len_Nat-byte signed number in big endian format>
@@ -113,6 +15,105 @@ object PickleFormat {
    *   ConstAnnotArg      = Constant | AnnotInfo | AnnotArgArray
    *
    *   len is remaining length after `len`.
+   *
+   *   Entry = \
+   *     1 TERMNAME len_Nat NameInfo
+   *   | 2 TYPENAME len_Nat NameInfo
+   *   |
+   *   | 3   NONEsym len_Nat
+   *   | 4   TYPEsym len_Nat SymbolInfo
+   *   | 5  ALIASsym len_Nat SymbolInfo
+   *   | 6  CLASSsym len_Nat SymbolInfo [thistype_Ref]
+   *   | 7 MODULEsym len_Nat SymbolInfo
+   *   | 8    VALsym len_Nat [defaultGetter_Ref] SymbolInfo [alias_Ref]  // defaultGetter_Ref no longer needed
+   *   |
+   *   | 9          EXTref len_Nat name_Ref [owner_Ref]
+   *   | 10 EXTMODCLASSref len_Nat name_Ref [owner_Ref]
+   *   |
+   *   | 11             NOtpe len_Nat
+   *   | 12       NOPREFIXtpe len_Nat
+   *   | 13           THIStpe len_Nat      sym_Ref
+   *   | 14         SINGLEtpe len_Nat     type_Ref  sym_Ref
+   *   | 15       CONSTANTtpe len_Nat constant_Ref
+   *   | 16        TYPEREFtpe len_Nat     type_Ref  sym_Ref {targ_Ref}
+   *   | 17     TYPEBOUNDStpe len_Nat      tpe_Ref  tpe_Ref
+   *   | 18        REFINEDtpe len_Nat classsym_Ref {tpe_Ref}
+   *   | 19      CLASSINFOtpe len_Nat classsym_Ref {tpe_Ref}
+   *   | 20         METHODtpe len_Nat      tpe_Ref {sym_Ref}
+   *   | 21          POLYTtpe len_Nat      tpe_Ref {sym_Ref}
+   *   | 22 IMPLICITMETHODtpe len_Nat      tpe_Ref {sym_Ref}   // deprecated
+   *   | 52          SUPERtpe len_Nat      tpe_Ref  tpe_Ref
+   *   |
+   *   | 24 LITERALunit    len_Nat
+   *   | 25 LITERALboolean len_Nat value_Long
+   *   | 26 LITERALbyte    len_Nat value_Long
+   *   | 27 LITERALshort   len_Nat value_Long
+   *   | 28 LITERALchar    len_Nat value_Long
+   *   | 29 LITERALint     len_Nat value_Long
+   *   | 30 LITERALlong    len_Nat value_Long
+   *   | 31 LITERALfloat   len_Nat value_Long
+   *   | 32 LITERALdouble  len_Nat value_Long
+   *   | 33 LITERALstring  len_Nat  name_Ref
+   *   | 34 LITERALnull    len_Nat
+   *   | 35 LITERALclass   len_Nat   tpe_Ref
+   *   | 36 LITERALenum    len_Nat   sym_Ref
+   *   | 37 LITERALsymbol  len_Nat  name_Ref
+   *   |
+   *   | 40 SYMANNOT         len_Nat            sym_Ref  AnnotInfoBody
+   *   | 41 CHILDREN         len_Nat            sym_Ref     {sym_Ref}
+   *   | 42     ANNOTATEDtpe len_Nat           [sym_Ref]     tpe_Ref {annotinfo_Ref} // sym_Ref no longer needed
+   *   | 43 ANNOTINFO        len_Nat      AnnotInfoBody
+   *   | 44 ANNOTARGARRAY    len_Nat {constAnnotArg_Ref}
+   *   | 47 DEBRUIJNINDEXtpe len_Nat          level_Nat    index_Nat   // deprecated
+   *   | 48   EXISTENTIALtpe len_Nat           type_Ref  {symbol_Ref}
+   *   |
+   *   | 49 TREE len_Nat
+   *   |    1           EMPTYtree
+   *   |    2         PACKAGEtree type_Ref      sym_Ref        mods_Ref  name_Ref      {tree_Ref}
+   *   |    3           CLASStree type_Ref      sym_Ref        mods_Ref  name_Ref       tree_Ref {tree_Ref}
+   *   |    4          MODULEtree type_Ref      sym_Ref        mods_Ref  name_Ref       tree_Ref
+   *   |    5          VALDEFtree type_Ref      sym_Ref        mods_Ref  name_Ref       tree_Ref  tree_Ref
+   *   |    6          DEFDEFtree type_Ref      sym_Ref        mods_Ref  name_Ref numtparams_Nat {tree_Ref} numparamss_Nat {numparams_Nat {tree_Ref}} tree_Ref tree_Ref
+   *   |    7         TYPEDEFtree type_Ref      sym_Ref        mods_Ref  name_Ref       tree_Ref {tree_Ref}
+   *   |    8           LABELtree type_Ref      sym_Ref        tree_Ref {tree_Ref}
+   *   |    9          IMPORTtree type_Ref      sym_Ref        tree_Ref {name_Ref       name_Ref}
+   *   |   11          DOCDEFtree type_Ref      sym_Ref      string_Ref  tree_Ref
+   *   |   12        TEMPLATEtree type_Ref      sym_Ref  numparents_Nat {tree_Ref}      tree_Ref {tree_Ref}
+   *   |   13           BLOCKtree type_Ref     tree_Ref       {tree_Ref}
+   *   |   14            CASEtree type_Ref     tree_Ref        tree_Ref  tree_Ref
+   *   |   15        SEQUENCEtree type_Ref    {tree_Ref}
+   *   |   16     ALTERNATIVEtree type_Ref    {tree_Ref}
+   *   |   17            STARtree type_Ref    {tree_Ref}
+   *   |   18            BINDtree type_Ref      sym_Ref  name_Ref  tree_Ref
+   *   |   19         UNAPPLYtree type_Ref     tree_Ref {tree_Ref}
+   *   |   20      ARRAYVALUEtree type_Ref     tree_Ref {tree_Ref}
+   *   |   21        FUNCTIONtree type_Ref      sym_Ref  tree_Ref {tree_Ref}
+   *   |   22          ASSIGNtree type_Ref     tree_Ref  tree_Ref
+   *   |   23              IFtree type_Ref     tree_Ref  tree_Ref  tree_Ref
+   *   |   24           MATCHtree type_Ref     tree_Ref {tree_Ref}
+   *   |   25          RETURNtree type_Ref      sym_Ref  tree_Ref
+   *   |   26             TREtree type_Ref     tree_Ref  tree_Ref {tree_Ref}
+   *   |   27           THROWtree type_Ref     tree_Ref
+   *   |   28             NEWtree type_Ref     tree_Ref
+   *   |   29           TYPEDtree type_Ref     tree_Ref  tree_Ref
+   *   |   30       TYPEAPPLYtree type_Ref     tree_Ref {tree_Ref}
+   *   |   31           APPLYtree type_Ref     tree_Ref {tree_Ref}
+   *   |   32    APPLYDYNAMICtree type_Ref      sym_Ref  tree_Ref {tree_Ref}
+   *   |   33           SUPERtree type_Ref      sym_Ref  tree_Ref  name_Ref
+   *   |   34            THIStree type_Ref      sym_Ref  name_Ref
+   *   |   35          SELECTtree type_Ref      sym_Ref  tree_Ref  name_Ref
+   *   |   36           IDENTtree type_Ref      sym_Ref  name_Ref
+   *   |   37         LITERALtree type_Ref constant_Ref
+   *   |   38            TYPEtree type_Ref
+   *   |   39       ANNOTATEDtree type_Ref     tree_Ref  tree_Ref
+   *   |   40   SINGLETONTYPEtree type_Ref     tree_Ref
+   *   |   41  SELECTFROMTYPEtree type_Ref     tree_Ref  name_Ref
+   *   |   42    COMPOUNDTYPEtree type_Ref     tree_Ref
+   *   |   43     APPLIEDTYPEtree type_Ref     tree_Ref {tree_Ref}
+   *   |   44      TYPEBOUNDStree type_Ref     tree_Ref  tree_Ref
+   *   |   45 EXISTENTIALTYPEtree type_Ref     tree_Ref {tree_Ref}
+   *   |
+   *   | 50 MODIFIERS len_Nat flags_Long privateWithin_Ref
    */
 
   val MajorVersion = 5
@@ -221,6 +222,10 @@ object PickleFormat {
     final val EXISTENTIALTYPEtree = 45
 
   final val MODIFIERS         = 50
+
+  final val   firstSymTag = NONEsym
+  final val    lastSymTag = VALsym
+  final val lastExtSymTag = EXTMODCLASSref
 
   def tag2string(tag: Int): String = tag match {
     case TERMname          => "TERMname"

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -24,6 +24,8 @@ object MimaSettings {
       // * com.typesafe.tools.mima.core.ProblemFilters
       // * com.typesafe.tools.mima.core.*Problem
       // * com.typesafe.tools.mima.core.util.log.Logging
+      exclude[Problem]("*mima.core.MimaUnpickler*"),
+      exclude[Problem]("*mima.core.PickleBuffer*"),
     ),
   )
 }


### PR DESCRIPTION
I hoped to be able to completely handle this without unpickling the
types.  The reported case pushed me to exploring it, but when I realised
it would require reimplementing erasure logic I backed out again.

Fixes #630