### PR TITLE
Allow introducing new signatures, ignore non-generic signatures

### DIFF
--- a/functional-tests/src/test/class-method-generics-nok/problems.txt
+++ b/functional-tests/src/test/class-method-generics-nok/problems.txt
@@ -1,11 +1,7 @@
 method backwardsCompatibleNarrowing()scala.Option in class A has a different generic signature in new version, where it is ()Lscala/Option<Ljava/lang/String;>; rather than ()Lscala/Option<Ljava/lang/Object;>;. See https://github.com/lightbend/mima#incompatiblesignatureproblem
 #
-method cov1()java.lang.Object in class Api has a different generic signature in new version, where it is <T:Ljava/lang/Object;>()TT; rather than <missing>. See https://github.com/lightbend/mima#incompatiblesignatureproblem
 method cov2()java.lang.Object in class Api has a different generic signature in new version, where it is <missing> rather than <T:Ljava/lang/Object;>()TT;. See https://github.com/lightbend/mima#incompatiblesignatureproblem
-method con1(java.lang.Object)Unit in class Api has a different generic signature in new version, where it is <T:Ljava/lang/Object;>(TT;)V rather than <missing>. See https://github.com/lightbend/mima#incompatiblesignatureproblem
 method con2(java.lang.Object)Unit in class Api has a different generic signature in new version, where it is <missing> rather than <T:Ljava/lang/Object;>(TT;)V. See https://github.com/lightbend/mima#incompatiblesignatureproblem
 #
-abstract method cov1()java.lang.Object in class Abi has a different generic signature in new version, where it is <T:Ljava/lang/Object;>()TT; rather than <missing>. See https://github.com/lightbend/mima#incompatiblesignatureproblem
 abstract method cov2()java.lang.Object in class Abi has a different generic signature in new version, where it is <missing> rather than <T:Ljava/lang/Object;>()TT;. See https://github.com/lightbend/mima#incompatiblesignatureproblem
-abstract method con1(java.lang.Object)Unit in class Abi has a different generic signature in new version, where it is <T:Ljava/lang/Object;>(TT;)V rather than <missing>. See https://github.com/lightbend/mima#incompatiblesignatureproblem
 abstract method con2(java.lang.Object)Unit in class Abi has a different generic signature in new version, where it is <missing> rather than <T:Ljava/lang/Object;>(TT;)V. See https://github.com/lightbend/mima#incompatiblesignatureproblem


### PR DESCRIPTION
When a new version has a signature and the old version didn't,
we assume this is compatible.

We don't need to check signatures for non-generic methods, since
for those it is sufficient to check for a matching descriptor.
Introducing or dropping signatures for those isn't relevant to
compatibility.

Hopefully fixes #693