### PR TITLE
Scala 2.13.10 (was .8)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ commands += Command.command("testStaging") { state =>
 
 // Keep in sync with TestCli
 val scala212 = "2.12.17"
-val scala213 = "2.13.8"
+val scala213 = "2.13.10"
 val scala3 = "3.2.0"
 
 val root = project.in(file(".")).settings(

--- a/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCli.scala
+++ b/functional-tests/src/main/scala/com/typesafe/tools/mima/lib/TestCli.scala
@@ -11,7 +11,7 @@ object TestCli {
   // Keep in sync with build.sbt
   val scala211 = "2.11.12"
   val scala212 = "2.12.17"
-  val scala213 = "2.13.8"
+  val scala213 = "2.13.10"
   val scala3   = "3.2.0"
   val hostScalaVersion = StdLibProps.scalaPropOrNone("maven.version.number").get
   val allScalaVersions = List(scala211, scala212, scala213, scala3)


### PR DESCRIPTION
not waiting for the steward, because I'm investigating a community build failure over at https://github.com/scala/community-build/pull/1606 and I'm curious to see if CI likes this here