### PR TITLE
use the same base classpath for empty packages as is used for normal packages

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/lib/MiMaLib.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/lib/MiMaLib.scala
@@ -23,7 +23,7 @@ final class MiMaLib(cp: Seq[File], log: Logging = ConsoleLogging) {
 
   private def createEmptyPackage(missingDirOrJar: File): PackageInfo = {
     log.debug(s"not a directory or jar file: $missingDirOrJar.  This is normal for POM-only modules.  Proceeding with empty set of packages.")
-    val defs = new Definitions(ClassPath.base)
+    val defs = new Definitions(classpath)
     new DefinitionsTargetPackageInfo(defs.root)
   }
 

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/pom-only-project/build.sbt
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/pom-only-project/build.sbt
@@ -1,0 +1,9 @@
+organization := "com.typesafe"
+name := "pom-only-project"
+version := "1.1.0"
+mimaPreviousArtifacts := Set(organization.value %% moduleName.value % "1.0.0")
+scalaVersion := "2.13.11"
+
+// this is an arbitrary dependency, but one that's known to cause issues in POM-only projects
+// see https://github.com/lightbend/mima/issues/768 for more context
+libraryDependencies += "com.twitter" %% "util-core" % "22.7.0"

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/pom-only-project/project/plugins.sbt
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/pom-only-project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % System.getProperty("plugin.version"))

--- a/sbtplugin/src/sbt-test/sbt-mima-plugin/pom-only-project/test
+++ b/sbtplugin/src/sbt-test/sbt-mima-plugin/pom-only-project/test
@@ -1,0 +1,6 @@
+> set version := "1.0.0"
+> publishLocal
+
+> reload
+
+> mimaReportBinaryIssues


### PR DESCRIPTION
References #768, #702, #743

Like @rossabaker in #743, I also don't know much about MiMa's internals, but from what I've poked around at, this seems to make sense?