### PR TITLE
add explicit type

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/PackageInfo.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/PackageInfo.scala
@@ -10,11 +10,11 @@ sealed class SyntheticPackageInfo(val owner: PackageInfo, val name: String) exte
 }
 
 object NoPackageInfo extends PackageInfo {
-  val name        = "<no package>"
-  val owner       = this
-  def definitions = sys.error("Called definitions on NoPackageInfo")
-  val packages    = mutable.Map.empty[String, PackageInfo]
-  val classes     = Map.empty[String, ClassInfo]
+  val name                     = "<no package>"
+  val owner: PackageInfo       = this
+  def definitions: Definitions = sys.error("Called definitions on NoPackageInfo")
+  val packages                 = mutable.Map.empty[String, PackageInfo]
+  val classes                  = Map.empty[String, ClassInfo]
 }
 
 sealed class ConcretePackageInfo(val owner: PackageInfo, cp: ClassPath, pkg: String, defs: Definitions)


### PR DESCRIPTION
prepare Scala 2.13.12

- https://github.com/scala/scala/pull/10439
- https://github.com/scala/community-build/blob/12866dc60bf80ea569f8a7e4d229a8afe04d84a1/proj/mima.conf#L16-L18


```
[error] core/src/main/scala/com/typesafe/tools/mima/core/PackageInfo.scala:14:7: under -Xsource:3, inferred com.typesafe.tools.mima.core.PackageInfo instead of com.typesafe.tools.mima.core.NoPackageInfo.type [quickfixable]
[error] Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=com.typesafe.tools.mima.core.NoPackageInfo.owner
[error]   val owner       = this
[error]       ^
[error] core/src/main/scala/com/typesafe/tools/mima/core/PackageInfo.scala:15:7: under -Xsource:3, inferred com.typesafe.tools.mima.core.Definitions instead of Nothing [quickfixable]
[error] Scala 3 migration messages are errors under -Xsource:3. Use -Wconf / @nowarn to filter them or add -Xmigration to demote them to warnings.
[error] Applicable -Wconf / @nowarn filters for this fatal warning: msg=<part of the message>, cat=scala3-migration, site=com.typesafe.tools.mima.core.NoPackageInfo.definitions
[error]   def definitions = sys.error("Called definitions on NoPackageInfo")
[error]       ^
```