### PR TITLE
ProblemReporting: support more non-wildcard digits

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/ProblemReporting.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ProblemReporting.scala
@@ -4,12 +4,12 @@ import scala.util.Try
 
 private[mima] object ProblemReporting {
   val versionOrdering: Ordering[String] = {
-    // version string "x.y.z" is converted to an Int tuple (x, y, z) for comparison
+    // version string "x.y.z" is converted to a Long tuple (x, y, z) for comparison
     val VersionRegex = """(\d+)\.?(\d+)?\.?(.*)?""".r
-    def int(versionPart: String) =
-      Try(versionPart.replace("x", Long.MaxValue.toString).filter(_.isDigit).toInt).getOrElse(0)
-    Ordering[(Int, Int, Int)].on[String] {
-      case VersionRegex(x, y, z) => (int(x), int(y), int(z))
+    def long(versionPart: String) =
+      Try(versionPart.replace("x", Long.MaxValue.toString).filter(_.isDigit).toLong).getOrElse(0L)
+    Ordering[(Long, Long, Long)].on[String] {
+      case VersionRegex(x, y, z) => (long(x), long(y), long(z))
       case bad => throw new IllegalArgumentException(bad)
     }
   }

--- a/core/src/main/scala/com/typesafe/tools/mima/core/ProblemReporting.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/ProblemReporting.scala
@@ -7,7 +7,7 @@ private[mima] object ProblemReporting {
     // version string "x.y.z" is converted to an Int tuple (x, y, z) for comparison
     val VersionRegex = """(\d+)\.?(\d+)?\.?(.*)?""".r
     def int(versionPart: String) =
-      Try(versionPart.replace("x", Short.MaxValue.toString).filter(_.isDigit).toInt).getOrElse(0)
+      Try(versionPart.replace("x", Long.MaxValue.toString).filter(_.isDigit).toInt).getOrElse(0)
     Ordering[(Int, Int, Int)].on[String] {
       case VersionRegex(x, y, z) => (int(x), int(y), int(z))
       case bad => throw new IllegalArgumentException(bad)


### PR DESCRIPTION
Currently versioned exclusion files don't work correctly for version strings like those from sbt-dynver, because it looks at all the digits after the last period. However the digits of a version string like `3.6.1+42-c80fbe6a+20250708-2356-SNAPSHOT` create a number far greater than `Short.MaxValue`. It's even larger than `Int.MaxValue.` So the easiest fix seems to be to just go with `Long.MaxValue`.