### PR TITLE
Add new TASTy tags

### DIFF
--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyFormat.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyFormat.scala
@@ -282,6 +282,9 @@ object TastyFormat {
   val INVISIBLE     = 44
   val EMPTYCLAUSE   = 45
   val SPLITCLAUSE   = 46
+  val TRACKED       = 47
+  val SUBMATCH      = 48
+  val INTO          = 49
 
   val AstCat2       = 60 to  89      // Cat. 2: tag Nat
   val SHAREDterm    = 60
@@ -316,6 +319,8 @@ object TastyFormat {
   val RECtype            = 100
   val SINGLETONtpt       = 101
   val BOUNDED            = 102
+  val EXPLICITtpt        = 103
+  val ELIDED             = 104
 
   val AstCat4       = 100 to 127     // Cat. 4: tag Nat AST
   val IDENT         = 110
@@ -377,10 +382,16 @@ object TastyFormat {
   val TYPEREFin      = 175
   val  SELECTin      = 176
   val EXPORT         = 177
+  val QUOTE          = 178
+  val SPLICE         = 179
   val METHODtype     = 180
+  val APPLYsigpoly   = 181
+  val QUOTEPATTERN   = 182
+  val SPLICEPATTERN  = 183
   val MATCHtype      = 190
   val MATCHtpt       = 191
   val MATCHCASEtype  = 192
+  val FLEXIBLEtype   = 193
   val HOLE           = 255
 
   /** Standard-Section: "Positions" LinesSizes Assoc*

--- a/core/src/main/scala/com/typesafe/tools/mima/core/TastyTagOps.scala
+++ b/core/src/main/scala/com/typesafe/tools/mima/core/TastyTagOps.scala
@@ -57,6 +57,8 @@ object TastyTagOps {
     case TRANSPARENT        => true
     case INFIX              => true
     case INVISIBLE          => true
+    case TRACKED            => true
+    case INTO               => true
     case ANNOTATION         => true
     case   PRIVATEqualified => true
     case PROTECTEDqualified => true
@@ -107,6 +109,9 @@ object TastyTagOps {
     case INVISIBLE     => "INVISIBLE"
     case EMPTYCLAUSE   => "EMPTYCLAUSE"
     case SPLITCLAUSE   => "SPLITCLAUSE"
+    case TRACKED       => "TRACKED"
+    case SUBMATCH      => "SUBMATCH"
+    case INTO          => "INTO"
 
     case SHAREDterm    => "SHAREDterm"
     case SHAREDtype    => "SHAREDtype"
@@ -139,6 +144,8 @@ object TastyTagOps {
     case RECtype            => "RECtype"
     case SINGLETONtpt       => "SINGLETONtpt"
     case BOUNDED            => "BOUNDED"
+    case EXPLICITtpt        => "EXPLICITtpt"
+    case ELIDED             => "ELIDED"
 
     case IDENT         => "IDENT"
     case IDENTtpt      => "IDENTtpt"
@@ -198,10 +205,16 @@ object TastyTagOps {
     case TYPEREFin      => "TYPEREFin"
     case  SELECTin      =>  "SELECTin"
     case EXPORT         => "EXPORT"
+    case QUOTE          => "QUOTE"
+    case SPLICE         => "SPLICE"
     case METHODtype     => "METHODtype"
+    case APPLYsigpoly   => "APPLYsigpoly"
+    case QUOTEPATTERN   => "QUOTEPATTERN"
+    case SPLICEPATTERN  => "SPLICEPATTERN"
     case MATCHtype      => "MATCHtype"
     case MATCHtpt       => "MATCHtpt"
     case MATCHCASEtype  => "MATCHCASEtype"
+    case FLEXIBLEtype   => "FLEXIBLEtype"
     case HOLE           => "HOLE"
 
     case tag => s"BadTag($tag)"


### PR DESCRIPTION
Adds missing TASTy tags:
TRACKED, SUBMATCH, INTO, EXPLICITtpt, ELIDED, QUOTE, SPLICE, APPLYsigpoly, QUOTEPATTERN, SPLICEPATTERN, FLEXIBLEtype

The lack of these tags causes MiMa to fail with `AssertionError: illegal modifier tag` e.g. when parsing TASTy files with `into traits`. See https://github.com/scala/scala3/actions/runs/27418861401/job/81038756631